### PR TITLE
Update ant / javac language targets

### DIFF
--- a/app/build.xml
+++ b/app/build.xml
@@ -28,8 +28,8 @@
     <!-- env used to set classpath below -->
     <property environment="env" />
 
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   destdir="bin"
 	   excludes="**/tools/format/**"
 	   encoding="UTF-8"

--- a/build/jre/build.xml
+++ b/build/jre/build.xml
@@ -22,8 +22,8 @@
       <!-- Where can I expect to find Java Mode JARs? -->
       <property name="java.mode" value="../../java/mode/" />
 
-      <javac source="1.8"
-          target="1.8"
+      <javac source="11"
+          target="11"
           srcdir="@{srcdir}"
           destdir="@{destdir}"
           debug="true"

--- a/core/build.xml
+++ b/core/build.xml
@@ -63,8 +63,8 @@
 
       <!-- link against apple.jar for the ThinkDifferent class -->
       <mkdir dir="@{destdir}" />
-      <javac source="1.8"
-  	   target="1.8"
+      <javac source="11"
+  	   target="11"
   	   encoding="UTF-8"
   	   includeAntRuntime="false"
   	   debug="true"

--- a/core/methods/build.xml
+++ b/core/methods/build.xml
@@ -3,14 +3,14 @@
   <target name="compile">
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-           target="1.8"
+    <javac source="11"
+           target="11"
 	   srcdir="src"
            destdir="bin"
 	   debug="true"
 	   includeantruntime="true"
 	   nowarn="true">
-     
+
     </javac>
   </target>
 

--- a/java/build.xml
+++ b/java/build.xml
@@ -104,8 +104,8 @@
       <!-- env used to set classpath below -->
       <property environment="env" />
 
-      <javac source="1.8"
-  	   target="1.8"
+      <javac source="11"
+  	   target="11"
   	   destdir="@{destdir}"
   	   excludes="**/tools/format/**"
   	   encoding="UTF-8"

--- a/java/libraries/dxf/build.xml
+++ b/java/libraries/dxf/build.xml
@@ -13,8 +13,8 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"

--- a/java/libraries/io/build.xml
+++ b/java/libraries/io/build.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0"?>
 <project name="Processing Hardware I/O Library" default="build">
-  
+
   <target name="clean" description="Clean the build directories">
     <delete dir="bin" />
     <delete file="library/io.jar" />
   </target>
-  
+
   <target name="compile" description="Compile sources">
     <condition property="core-built">
       <available file="../../../core/library/core.jar" />
     </condition>
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
-    
+
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
-	   srcdir="src" destdir="bin" 
+    <javac source="11"
+	   target="11"
+	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"
 	   classpath="../../../core/library/core.jar"
 	   nowarn="true"
 	   compiler="org.eclipse.jdt.core.JDTCompilerAdapter">
-      <compilerclasspath path="../../mode/org.eclipse.jdt.core.jar; 
+      <compilerclasspath path="../../mode/org.eclipse.jdt.core.jar;
                                ../../mode/jdtCompilerAdapter.jar" />
     </javac>
   </target>
-  
+
   <target name="build" depends="compile" description="Build I/O library">
     <jar basedir="bin" destfile="library/io.jar" />
   </target>

--- a/java/libraries/net/build.xml
+++ b/java/libraries/net/build.xml
@@ -13,8 +13,8 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"

--- a/java/libraries/pdf/build.xml
+++ b/java/libraries/pdf/build.xml
@@ -13,8 +13,8 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"

--- a/java/libraries/serial/build.xml
+++ b/java/libraries/serial/build.xml
@@ -13,8 +13,8 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"

--- a/java/libraries/svg/build.xml
+++ b/java/libraries/svg/build.xml
@@ -13,8 +13,8 @@
     <fail unless="core-built" message="Please build the core library first and make sure it sits in ../../../core/library/core.jar" />
 
     <mkdir dir="bin" />
-    <javac source="1.8"
-	   target="1.8"
+    <javac source="11"
+	   target="11"
 	   srcdir="src" destdir="bin"
 	   encoding="UTF-8"
 	   includeAntRuntime="false"


### PR DESCRIPTION
Bit of cleanup in the ant scripts around the build language source and target on javac, enabling use of Java 11 language features within the processing source itself.

Note that this is only impacting language feature availability: the build is currently sustained on either 1.8 or 11 in terms of language features but the code is no longer compatible with the Java 8 runtime due to backwards-incompatable changes made starting in Java 9 runtime.