### PR TITLE
Turn off swing automatic UI scaling for windows.

### DIFF
--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -30,6 +30,9 @@
     <!-- <opt>-Djava.ext.dirs="%EXEDIR%\\java\\lib\\ext"</opt> -->
     <!-- https://github.com/processing/processing/issues/2239 -->
     <opt>-Djna.nosys=true</opt>
+    <!-- Java 9+ handles high DPI internally so OS display scaling -->
+    <!-- can cause display issues with custom rendering swing elements. -->
+    <opt>-Dsun.java2d.uiScale.enabled=false</opt>
     <!-- Because nosys is set to true, the DLL in the current working
 	 directory won't be considered. And we can't specify the user's
 	 directory here because that'll get us into encoding trouble.


### PR DESCRIPTION
Frustratingly, use of prior Processing WindowsPlatform code for detecting DPI causes UI scaling to turn off and yields a DPI of 96 regardless of windows display scaling. However, in the current WindowsPlatform, UI scaling is enabled but text size calculation within custom rendering swing elements is incorrect, possibly because there is scaling happening underneath transparently. This causes x positions (for the caret rendering) to be inflated at 125% scaling, for example.

On a whole, Windows itself does not seem to (?) recommend scaling other than 100% inside the settings UI and that UI scaling within Java itself makes the other custom UI elements look bad. So, this suggests disabling the UI scaling in Java for the editor, leaving the opportunity for Processing to find a new way to detect system scaling in the future and handling it internally. At this time, sketches still seem to be calculating positions correctly though they do appear pixelated with display scaling. Therefore, they are left alone.

Resolves https://github.com/processing/processing4/issues/21 by disabling swing automatic UI scaling.

Note that scaling seems to be correct on other OS and this only impacts windows.