### PR TITLE
Fix display density detection and use GraphicsConfiguration.

### DIFF
--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -30,6 +30,7 @@ import java.awt.FontMetrics;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Image;
@@ -907,23 +908,14 @@ public class Toolkit {
   // A 5-minute search didn't turn up any such event in the Java API.
   // Also, should we use the Toolkit associated with the editor window?
   static private boolean checkRetina() {
-    if (Platform.isMacOS()) {
-      GraphicsEnvironment env = GraphicsEnvironment.getLocalGraphicsEnvironment();
-      GraphicsDevice device = env.getDefaultScreenDevice();
+    GraphicsDevice graphicsDevice = GraphicsEnvironment
+            .getLocalGraphicsEnvironment()
+            .getDefaultScreenDevice();
+    GraphicsConfiguration graphicsConfig = graphicsDevice
+            .getDefaultConfiguration();
 
-      try {
-        Field field = device.getClass().getDeclaredField("scale");
-        if (field != null) {
-          field.setAccessible(true);
-          Object scale = field.get(device);
-
-          if (scale instanceof Integer && ((Integer)scale).intValue() == 2) {
-            return true;
-          }
-        }
-      } catch (Exception ignore) { }
-    }
-    return false;
+    AffineTransform tx = graphicsConfig.getDefaultTransform();
+    return Math.round(tx.getScaleX()) == 2;
   }
 
 


### PR DESCRIPTION
Reflexive access is no longer allowed so we need to transition displayDensity and isRetina to GraphicsConfiguration. Note that I am letting the cross-platform interface work on its own without the operating system check but, in testing, I have only seen a scale == 1 on Windows and Linux.

Resolves #32 and resolves #35.