### PR TITLE
[WIP] Started migration to getModifiersEx.

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1765,7 +1765,7 @@ public class Base {
           String path = e.getActionCommand();
           if (new File(path).exists()) {
             boolean replace = replaceExisting;
-            if ((e.getModifiers() & ActionEvent.SHIFT_MASK) != 0) {
+            if ((e.getModifiers() & ActionEvent.SHIFT_DOWN_MASK) != 0) {
               replace = !replace;
             }
 //            if (replace) {

--- a/app/src/processing/app/syntax/DefaultInputHandler.java
+++ b/app/src/processing/app/syntax/DefaultInputHandler.java
@@ -161,8 +161,8 @@ public class DefaultInputHandler extends InputHandler
 
           // don't get command-s or other menu key equivs on mac
           // unless it's something that's specifically bound (cmd-left or right)
-          //if ((modifiers & KeyEvent.META_MASK) != 0) return;
-          if ((modifiers & InputEvent.META_MASK) != 0) {
+          //if ((modifiers & KeyEvent.META_DOWN_MASK) != 0) return;
+          if ((modifiers & InputEvent.META_DOWN_MASK) != 0) {
             KeyStroke keyStroke = KeyStroke.getKeyStroke(keyCode, modifiers);
             if (currentBindings.get(keyStroke) == null) {
               return;
@@ -177,7 +177,7 @@ public class DefaultInputHandler extends InputHandler
                                    KeyEvent.VK_META);
                 */
 
-                if((modifiers & ~InputEvent.SHIFT_MASK) != 0
+                if((modifiers & ~InputEvent.SHIFT_DOWN_MASK) != 0
                         || evt.isActionKey()
                         || keyCode == KeyEvent.VK_BACK_SPACE
                         || keyCode == KeyEvent.VK_DELETE
@@ -242,14 +242,14 @@ public class DefaultInputHandler extends InputHandler
                 // this is the apple/cmd key on macosx.. so menu commands
                 // were being passed through as legit keys.. added this line
                 // in an attempt to prevent.
-                if ((modifiers & InputEvent.META_MASK) != 0) return;
+                if ((modifiers & InputEvent.META_DOWN_MASK) != 0) return;
 
                 // Prevent CTRL-/ from going through as a typed '/' character
                 // http://code.google.com/p/processing/issues/detail?id=596
-                if ((modifiers & InputEvent.CTRL_MASK) != 0 && c == '/') return;
+                if ((modifiers & InputEvent.CTRL_DOWN_MASK) != 0 && c == '/') return;
 
                 if (c != KeyEvent.CHAR_UNDEFINED) // &&
-                  //                (modifiers & KeyEvent.ALT_MASK) == 0)
+                  //                (modifiers & KeyEvent.ALT_DOWN_MASK) == 0)
                 {
                   if(c >= 0x20 && c != 0x7f)
                         {
@@ -319,16 +319,16 @@ public class DefaultInputHandler extends InputHandler
                                         .charAt(i)))
                                 {
                                 case 'A':
-                                        modifiers |= InputEvent.ALT_MASK;
+                                        modifiers |= InputEvent.ALT_DOWN_MASK;
                                         break;
                                 case 'C':
-                                        modifiers |= InputEvent.CTRL_MASK;
+                                        modifiers |= InputEvent.CTRL_DOWN_MASK;
                                         break;
                                 case 'M':
-                                        modifiers |= InputEvent.META_MASK;
+                                        modifiers |= InputEvent.META_DOWN_MASK;
                                         break;
                                 case 'S':
-                                        modifiers |= InputEvent.SHIFT_MASK;
+                                        modifiers |= InputEvent.SHIFT_DOWN_MASK;
                                         break;
                                 }
                         }

--- a/app/src/processing/app/syntax/PdeInputHandler.java
+++ b/app/src/processing/app/syntax/PdeInputHandler.java
@@ -216,8 +216,8 @@ public class PdeInputHandler extends DefaultInputHandler {
     // Don't do this on OS X, because alt (the option key) is used for
     // non-ASCII chars, and there are no menu mnemonics to speak of
     if (!Platform.isMacOS()) {
-      if ((event.getModifiers() & InputEvent.ALT_MASK) != 0 &&
-          (event.getModifiers() & InputEvent.CTRL_MASK) == 0 &&
+      if ((event.getModifiers() & InputEvent.ALT_DOWN_MASK) != 0 &&
+          (event.getModifiers() & InputEvent.CTRL_DOWN_MASK) == 0 &&
           event.getKeyChar() != KeyEvent.VK_UNDEFINED) {
         // This is probably a menu mnemonic, don't pass it through.
         // If it's an alt-NNNN sequence, those only work on the keypad
@@ -232,7 +232,7 @@ public class PdeInputHandler extends DefaultInputHandler {
   public void keyPressed(KeyEvent event) {
     // don't pass the ctrl-, through to the editor
     // https://github.com/processing/processing/issues/3074
-    if ((event.getModifiers() & InputEvent.CTRL_MASK) != 0 &&
+    if ((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0 &&
         event.getKeyChar() == ',') {
       return;
     }

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -914,7 +914,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     menu.add(item);
 
     item = new JMenuItem("Move Selected Lines Up");
-    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_UP, Event.ALT_MASK));
+    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_UP, Event.ALT_DOWN_MASK));
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           handleMoveLines(true);
@@ -923,7 +923,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
     menu.add(item);
 
     item = new JMenuItem("Move Selected Lines Down");
-    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, Event.ALT_MASK));
+    item.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_DOWN, Event.ALT_DOWN_MASK));
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           handleMoveLines(false);

--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -95,10 +95,10 @@ public class Toolkit {
     awtToolkit.getMenuShortcutKeyMaskEx();
   /** Command-Option on Mac OS X, Ctrl-Alt on Windows and Linux */
   static final int SHORTCUT_ALT_KEY_MASK =
-    ActionEvent.ALT_MASK | SHORTCUT_KEY_MASK;
+    ActionEvent.ALT_DOWN_MASK | SHORTCUT_KEY_MASK;
   /** Command-Shift on Mac OS X, Ctrl-Shift on Windows and Linux */
   static final int SHORTCUT_SHIFT_KEY_MASK =
-    ActionEvent.SHIFT_MASK | SHORTCUT_KEY_MASK;
+    ActionEvent.SHIFT_DOWN_MASK | SHORTCUT_KEY_MASK;
 
   /** Command-W on Mac OS X, Ctrl-W on Windows and Linux */
   static public final KeyStroke WINDOW_CLOSE_KEYSTROKE =

--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -1280,39 +1280,36 @@ public class PSurfaceAWT extends PSurfaceNone {
       break;
     }
 
-    //System.out.println(nativeEvent);
-    //int modifiers = nativeEvent.getModifiersEx();
-    // If using getModifiersEx(), the regular modifiers don't set properly.
-    int modifiers = nativeEvent.getModifiers();
+    int modifiers = nativeEvent.getModifiersEx();
 
     int peModifiers = modifiers &
-      (InputEvent.SHIFT_MASK |
-       InputEvent.CTRL_MASK |
-       InputEvent.META_MASK |
-       InputEvent.ALT_MASK);
+      (InputEvent.SHIFT_DOWN_MASK |
+       InputEvent.CTRL_DOWN_MASK |
+       InputEvent.META_DOWN_MASK |
+       InputEvent.ALT_DOWN_MASK);
 
     // Windows and OS X seem to disagree on how to handle this. Windows only
-    // sets BUTTON1_DOWN_MASK, while OS X seems to set BUTTON1_MASK.
+    // sets BUTTON1_DOWN_MASK, while OS X seems to set BUTTON1_DOWN_MASK.
     // This is an issue in particular with mouse release events:
     // http://code.google.com/p/processing/issues/detail?id=1294
     // The fix for which led to a regression (fixed here by checking both):
     // http://code.google.com/p/processing/issues/detail?id=1332
     int peButton = 0;
-//    if ((modifiers & InputEvent.BUTTON1_MASK) != 0 ||
+//    if ((modifiers & InputEvent.BUTTON1_DOWN_MASK) != 0 ||
 //        (modifiers & InputEvent.BUTTON1_DOWN_MASK) != 0) {
 //      peButton = LEFT;
-//    } else if ((modifiers & InputEvent.BUTTON2_MASK) != 0 ||
+//    } else if ((modifiers & InputEvent.BUTTON2_DOWN_MASK) != 0 ||
 //               (modifiers & InputEvent.BUTTON2_DOWN_MASK) != 0) {
 //      peButton = CENTER;
-//    } else if ((modifiers & InputEvent.BUTTON3_MASK) != 0 ||
+//    } else if ((modifiers & InputEvent.BUTTON3_DOWN_MASK) != 0 ||
 //               (modifiers & InputEvent.BUTTON3_DOWN_MASK) != 0) {
 //      peButton = RIGHT;
 //    }
-    if ((modifiers & InputEvent.BUTTON1_MASK) != 0) {
+    if ((modifiers & InputEvent.BUTTON1_DOWN_MASK) != 0) {
       peButton = PConstants.LEFT;
-    } else if ((modifiers & InputEvent.BUTTON2_MASK) != 0) {
+    } else if ((modifiers & InputEvent.BUTTON2_DOWN_MASK) != 0) {
       peButton = PConstants.CENTER;
-    } else if ((modifiers & InputEvent.BUTTON3_MASK) != 0) {
+    } else if ((modifiers & InputEvent.BUTTON3_DOWN_MASK) != 0) {
       peButton = PConstants.RIGHT;
     }
 
@@ -1345,10 +1342,10 @@ public class PSurfaceAWT extends PSurfaceNone {
 //       InputEvent.META_DOWN_MASK |
 //       InputEvent.ALT_DOWN_MASK);
     int peModifiers = event.getModifiers() &
-      (InputEvent.SHIFT_MASK |
-       InputEvent.CTRL_MASK |
-       InputEvent.META_MASK |
-       InputEvent.ALT_MASK);
+      (InputEvent.SHIFT_DOWN_MASK |
+       InputEvent.CTRL_DOWN_MASK |
+       InputEvent.META_DOWN_MASK |
+       InputEvent.ALT_DOWN_MASK);
 
     sketch.postEvent(new KeyEvent(event, event.getWhen(),
                                   peAction, peModifiers,

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1035,10 +1035,10 @@ public class PSurfaceJOGL implements PSurface {
                                   int peAction) {
     int modifiers = nativeEvent.getModifiers();
     int peModifiers = modifiers &
-                      (InputEvent.SHIFT_MASK |
-                       InputEvent.CTRL_MASK |
-                       InputEvent.META_MASK |
-                       InputEvent.ALT_MASK);
+                      (InputEvent.SHIFT_DOWN_MASK |
+                       InputEvent.CTRL_DOWN_MASK |
+                       InputEvent.META_DOWN_MASK |
+                       InputEvent.ALT_DOWN_MASK);
 
     int peButton = 0;
     switch (nativeEvent.getButton()) {
@@ -1099,10 +1099,10 @@ public class PSurfaceJOGL implements PSurface {
   protected void nativeKeyEvent(com.jogamp.newt.event.KeyEvent nativeEvent,
                                 int peAction) {
     int peModifiers = nativeEvent.getModifiers() &
-                      (InputEvent.SHIFT_MASK |
-                       InputEvent.CTRL_MASK |
-                       InputEvent.META_MASK |
-                       InputEvent.ALT_MASK);
+                      (InputEvent.SHIFT_DOWN_MASK |
+                       InputEvent.CTRL_DOWN_MASK |
+                       InputEvent.META_DOWN_MASK |
+                       InputEvent.ALT_DOWN_MASK);
 
     short code = nativeEvent.getKeyCode();
     char keyChar;

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1173,11 +1173,11 @@ public class JavaEditor extends Editor {
       Messages.log("Invoked 'Step Over' menu item");
       debugger.stepOver();
 
-    } else if ((modifiers & ActionEvent.SHIFT_MASK) != 0) {
+    } else if ((modifiers & ActionEvent.SHIFT_DOWN_MASK) != 0) {
       Messages.log("Invoked 'Step Into' menu item");
       debugger.stepInto();
 
-    } else if ((modifiers & ActionEvent.ALT_MASK) != 0) {
+    } else if ((modifiers & ActionEvent.ALT_DOWN_MASK) != 0) {
       Messages.log("Invoked 'Step Out' menu item");
       debugger.stepOut();
     }
@@ -1419,7 +1419,7 @@ public class JavaEditor extends Editor {
     item = Toolkit.newJMenuItemExt("menu.debug.step_into");
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          handleStep(ActionEvent.SHIFT_MASK);
+          handleStep(ActionEvent.SHIFT_DOWN_MASK);
         }
       });
     debugMenu.add(item);
@@ -1428,7 +1428,7 @@ public class JavaEditor extends Editor {
     item = Toolkit.newJMenuItemExt("menu.debug.step_out");
     item.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
-          handleStep(ActionEvent.ALT_MASK);
+          handleStep(ActionEvent.ALT_DOWN_MASK);
         }
       });
     debugMenu.add(item);

--- a/java/src/processing/mode/java/JavaInputHandler.java
+++ b/java/src/processing/mode/java/JavaInputHandler.java
@@ -42,7 +42,7 @@ import processing.app.ui.Editor;
 public class JavaInputHandler extends PdeInputHandler {
 
 //  /** ctrl-alt on windows and linux, cmd-alt on mac os x */
-//  static final int CTRL_ALT = ActionEvent.ALT_MASK |
+//  static final int CTRL_ALT = ActionEvent.ALT_DOWN_MASK |
 //    Toolkit.getDefaultToolkit().getMenuShortcutKeyMask();
 
 
@@ -67,7 +67,7 @@ public class JavaInputHandler extends PdeInputHandler {
     JEditTextArea textarea = editor.getTextArea();
 
     if (event.isMetaDown()) {
-    //if ((event.getModifiers() & InputEvent.META_MASK) != 0) {
+    //if ((event.getModifiers() & InputEvent.META_DOWN_MASK) != 0) {
       //event.consume();  // does nothing
       return false;
     }
@@ -78,7 +78,7 @@ public class JavaInputHandler extends PdeInputHandler {
     }
 
     if ((code == KeyEvent.VK_UP) && event.isControlDown()) {
-        //((event.getModifiers() & InputEvent.CTRL_MASK) != 0)) {
+        //((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)) {
       // back up to the last empty line
       char contents[] = textarea.getText().toCharArray();
       //int origIndex = textarea.getCaretPosition() - 1;
@@ -105,7 +105,7 @@ public class JavaInputHandler extends PdeInputHandler {
       // if the first char, index will be -2
       if (index < 0) index = 0;
 
-      //if ((event.getModifiers() & InputEvent.SHIFT_MASK) != 0) {
+      //if ((event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0) {
       if (event.isShiftDown()) {
         textarea.setSelectionStart(caretIndex);
         textarea.setSelectionEnd(index);
@@ -116,7 +116,7 @@ public class JavaInputHandler extends PdeInputHandler {
 //      return true;
 
     } else if ((code == KeyEvent.VK_DOWN) && event.isControlDown()) {
-               //((event.getModifiers() & InputEvent.CTRL_MASK) != 0)) {
+               //((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0)) {
       char contents[] = textarea.getText().toCharArray();
       int caretIndex = textarea.getCaretPosition();
 
@@ -138,7 +138,7 @@ public class JavaInputHandler extends PdeInputHandler {
         index++;
       }
 
-      //if ((event.getModifiers() & InputEvent.SHIFT_MASK) != 0) {
+      //if ((event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0) {
       if (event.isShiftDown()) {
         textarea.setSelectionStart(caretIndex);
         textarea.setSelectionEnd(index);
@@ -149,7 +149,7 @@ public class JavaInputHandler extends PdeInputHandler {
 //      return true;
 
     } else if (c == 9) {
-      //if ((event.getModifiers() & InputEvent.SHIFT_MASK) != 0) {
+      //if ((event.getModifiers() & InputEvent.SHIFT_DOWN_MASK) != 0) {
       if (event.isShiftDown()) {
         // if shift is down, the user always expects an outdent
         // http://code.google.com/p/processing/issues/detail?id=458
@@ -321,7 +321,7 @@ public class JavaInputHandler extends PdeInputHandler {
   public boolean handleTyped(KeyEvent event) {
     char c = event.getKeyChar();
 
-    //if ((event.getModifiers() & InputEvent.CTRL_MASK) != 0) {
+    //if ((event.getModifiers() & InputEvent.CTRL_DOWN_MASK) != 0) {
     if (event.isControlDown()) {  // TODO true on typed? [fry 191007]
       // on linux, ctrl-comma (prefs) being passed through to the editor
       if (c == KeyEvent.VK_COMMA) {

--- a/java/src/processing/mode/java/JavaToolbar.java
+++ b/java/src/processing/mode/java/JavaToolbar.java
@@ -77,7 +77,7 @@ public class JavaToolbar extends EditorToolbar {
                                     Language.text("menu.debug.step_out")) {
         @Override
         public void actionPerformed(ActionEvent e) {
-          final int mask = ActionEvent.SHIFT_MASK | ActionEvent.ALT_MASK;
+          final int mask = ActionEvent.SHIFT_DOWN_MASK | ActionEvent.ALT_DOWN_MASK;
           jeditor.handleStep(e.getModifiers() & mask);
         }
       };
@@ -130,7 +130,7 @@ public class JavaToolbar extends EditorToolbar {
 
   @Override
   public void handleRun(int modifiers) {
-    boolean shift = (modifiers & ActionEvent.SHIFT_MASK) != 0;
+    boolean shift = (modifiers & ActionEvent.SHIFT_DOWN_MASK) != 0;
     if (shift) {
       jeditor.handlePresent();
     } else {


### PR DESCRIPTION
InputEvent.getModifiers has been [deprecated in Java 9](https://docs.oracle.com/javase/9/docs/api/java/awt/event/InputEvent.html). Migrated fields and will start testing. This is part of https://github.com/processing/processing4/issues/4.

Resolves #4.