### PR TITLE
remove redundant boxing and casting

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -597,8 +597,8 @@ public class PSurfaceAWT extends PSurfaceNone {
         Class<?> thinkDifferent =
           Thread.currentThread().getContextClassLoader().loadClass(td);
         Method method =
-          thinkDifferent.getMethod("setIconImage", new Class[] { java.awt.Image.class });
-        method.invoke(null, new Object[] { awtImage });
+          thinkDifferent.getMethod("setIconImage", Image.class);
+        method.invoke(null, awtImage);
       } catch (Exception e) {
         e.printStackTrace();  // That's unfortunate
       }
@@ -655,8 +655,8 @@ public class PSurfaceAWT extends PSurfaceNone {
           Class<?> thinkDifferent =
             Thread.currentThread().getContextClassLoader().loadClass(td);
           Method method =
-            thinkDifferent.getMethod("setIconImage", new Class[] { java.awt.Image.class });
-          method.invoke(null, new Object[] { Toolkit.getDefaultToolkit().getImage(url) });
+            thinkDifferent.getMethod("setIconImage", Image.class);
+          method.invoke(null, Toolkit.getDefaultToolkit().getImage(url));
         } catch (Exception e) {
           e.printStackTrace();  // That's unfortunate
         }

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1581,18 +1581,7 @@ public class PApplet implements PConstants {
     }
   }
 
-
-  protected void handleMethods(String methodName) {
-    synchronized (registerLock) {
-      RegisteredMethods meth = registerMap.get(methodName);
-      if (meth != null) {
-        meth.handle();
-      }
-    }
-  }
-
-
-  protected void handleMethods(String methodName, Object[] args) {
+  protected void handleMethods(String methodName, Object...args) {
     synchronized (registerLock) {
       RegisteredMethods meth = registerMap.get(methodName);
       if (meth != null) {
@@ -2223,7 +2212,7 @@ public class PApplet implements PConstants {
       Class<?> rendererClass =
         Thread.currentThread().getContextClassLoader().loadClass(renderer);
 
-      Constructor<?> constructor = rendererClass.getConstructor(new Class[] { });
+      Constructor<?> constructor = rendererClass.getConstructor();
       PGraphics pg = (PGraphics) constructor.newInstance();
 
       pg.setParent(this);
@@ -2707,7 +2696,7 @@ public class PApplet implements PConstants {
       break;
     }
 
-    handleMethods("mouseEvent", new Object[] { event });
+    handleMethods("mouseEvent", event);
 
     switch (action) {
     case MouseEvent.PRESS:
@@ -2979,7 +2968,7 @@ public class PApplet implements PConstants {
     }
     */
 
-    handleMethods("keyEvent", new Object[] { event });
+    handleMethods("keyEvent", event);
 
     // if someone else wants to intercept the key, they should
     // set key to zero (or something besides the ESC).
@@ -3824,8 +3813,8 @@ public class PApplet implements PConstants {
    */
   public void method(String name) {
     try {
-      Method method = getClass().getMethod(name, new Class[] {});
-      method.invoke(this, new Object[] { });
+      Method method = getClass().getMethod(name);
+      method.invoke(this);
 
     } catch (IllegalArgumentException e) {
       e.printStackTrace();
@@ -6676,8 +6665,8 @@ public class PApplet implements PConstants {
     try {
       Class<?> callbackClass = callbackObject.getClass();
       Method selectMethod =
-        callbackClass.getMethod(callbackMethod, new Class[] { File.class });
-      selectMethod.invoke(callbackObject, new Object[] { selectedFile });
+        callbackClass.getMethod(callbackMethod, File.class);
+      selectMethod.invoke(callbackObject, selectedFile);
 
     } catch (IllegalAccessException iae) {
       System.err.println(callbackMethod + "() must be public");
@@ -10802,8 +10791,8 @@ public class PApplet implements PConstants {
         Class<?> thinkDifferent =
           Thread.currentThread().getContextClassLoader().loadClass(td);
         Method method =
-          thinkDifferent.getMethod("init", new Class[] { PApplet.class });
-        method.invoke(null, new Object[] { sketch });
+          thinkDifferent.getMethod("init", PApplet.class);
+        method.invoke(null, sketch);
       } catch (Exception e) {
         e.printStackTrace();  // That's unfortunate
       }

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -1062,7 +1062,7 @@ public class Table {
         con = target.getDeclaredConstructor();  //new Class[] { });
 //        PApplet.println("no enclosing class");
       } else {
-        con = target.getDeclaredConstructor(new Class[] { enclosingClass });
+        con = target.getDeclaredConstructor(enclosingClass);
 //        PApplet.println("enclosed by " + enclosingClass.getName());
       }
       if (!con.canAccess(null)) {
@@ -1509,17 +1509,15 @@ public class Table {
     entry = new ZipEntry("content.xml");
     zos.putNextEntry(entry);
     //lines = new String[] {
-    writeUTF(zos, new String[] {
-      xmlHeader,
-      "<office:document-content" +
-        " xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\"" +
-        " xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\"" +
-        " xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\"" +
-        " office:version=\"1.2\">",
-     "  <office:body>",
-     "    <office:spreadsheet>",
-     "      <table:table table:name=\"Sheet1\" table:print=\"false\">"
-    });
+    writeUTF(zos, xmlHeader,
+            "<office:document-content" +
+              " xmlns:office=\"urn:oasis:names:tc:opendocument:xmlns:office:1.0\"" +
+              " xmlns:text=\"urn:oasis:names:tc:opendocument:xmlns:text:1.0\"" +
+              " xmlns:table=\"urn:oasis:names:tc:opendocument:xmlns:table:1.0\"" +
+              " office:version=\"1.2\">",
+            "  <office:body>",
+            "    <office:spreadsheet>",
+            "      <table:table table:name=\"Sheet1\" table:print=\"false\">");
     //zos.write(PApplet.join(lines, "\n").getBytes());
 
     byte[] rowStart = "        <table:table-row>\n".getBytes();
@@ -1546,12 +1544,10 @@ public class Table {
     }
 
     //lines = new String[] {
-    writeUTF(zos, new String[] {
-      "      </table:table>",
-      "    </office:spreadsheet>",
-      "  </office:body>",
-      "</office:document-content>"
-    });
+    writeUTF(zos, "      </table:table>",
+            "    </office:spreadsheet>",
+            "  </office:body>",
+            "</office:document-content>");
     //zos.write(PApplet.join(lines, "\n").getBytes());
     zos.closeEntry();
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -53,7 +53,7 @@ public class PGraphicsOpenGL extends PGraphics {
   // Using the technique alternative to finalization described in:
   // http://www.oracle.com/technetwork/articles/java/finalization-137655.html
   private static ReferenceQueue<Object> refQueue = new ReferenceQueue<>();
-  private static List<Disposable<? extends Object>> reachableWeakReferences =
+  private static List<Disposable<?>> reachableWeakReferences =
     new LinkedList<>();
 
   static final private int MAX_DRAIN_GLRES_ITERATIONS = 10;
@@ -61,8 +61,8 @@ public class PGraphicsOpenGL extends PGraphics {
   static void drainRefQueueBounded() {
     int iterations = 0;
     while (iterations < MAX_DRAIN_GLRES_ITERATIONS) {
-      Disposable<? extends Object> res =
-        (Disposable<? extends Object>) refQueue.poll();
+      Disposable<?> res =
+        (Disposable<?>) refQueue.poll();
       if (res == null) {
         break;
       }

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -1469,7 +1469,7 @@ public class PJOGL extends PGL {
 
   @Override
   public void shaderSource(int shader, String source) {
-    gl2.glShaderSource(shader, 1, new String[] { source }, (int[]) null, 0);
+    gl2.glShaderSource(shader, 1, new String[] { source }, null, 0);
   }
 
   @Override

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -4681,7 +4681,7 @@ public class PShapeOpenGL extends PShape {
         if (family == GROUP) {
           if (fragmentedGroup(gl)) {
             for (int i = 0; i < childCount; i++) {
-              ((PShapeOpenGL) children[i]).draw(gl);
+              children[i].draw(gl);
             }
           } else {
             PImage tex = null;

--- a/core/src/processing/opengl/Texture.java
+++ b/core/src/processing/opengl/Texture.java
@@ -925,7 +925,7 @@ public class Texture implements PConstants {
   protected void getSourceMethods() {
     try {
       disposeBufferMethod = bufferSource.getClass().
-        getMethod("disposeBuffer", new Class[] { Object.class });
+        getMethod("disposeBuffer", Object.class);
     } catch (Exception e) {
       throw new RuntimeException("Provided source object doesn't have a " +
                                  "disposeBuffer method.");
@@ -1659,7 +1659,7 @@ public class Texture implements PConstants {
     void dispose() {
       try {
         // Disposing the native buffer.
-        disposeBufferMethod.invoke(bufferSource, new Object[] { natBuf });
+        disposeBufferMethod.invoke(bufferSource, natBuf);
         natBuf = null;
         rgbBuf = null;
       } catch (Exception e) {


### PR DESCRIPTION
Removed array instantiation where parameters could be accepted as VArgs
callbackClass.getMethod(callbackMethod, new Class[] { File.class }); =>
callbackClass.getMethod(callbackMethod, File.class);

Remove redundant unboxing where appropriate
(scale instanceof Integer && ((Integer)scale).intValue() == 2) =>
(scale instanceof Integer && (Integer) scale == 2)
In this case scale will automaticaly be unboxed to it's int value

Replace protected void handleMethods(String methodName) and
protected void handleMethods(String methodName, Object[] args)
with
protected void handleMethods(String methodName, Object...args)
as it handles both cases

Remove redundant extends Object clause from type wildcards
List<Disposable<? extends Object>> reachableWeakReferences =>
List<Disposable<?>> reachableWeakReferences