### PR TITLE
Resolve PDF renderer parse issue in preproc.

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -73,8 +73,9 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
   private String sketchWidth;
   private String sketchHeight;
-  private String sketchRenderer;
   private String pixelDensity;
+  private String sketchRenderer = null;
+  private String sketchOutputFilename = null;
 
   private boolean sizeRequiresRewrite = false;
   private boolean pixelDensityRequiresRewrite = false;
@@ -627,9 +628,14 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
               sketchRenderer.equals("P3D") ||
               sketchRenderer.equals("OPENGL") ||
               sketchRenderer.equals("JAVA2D") ||
+              sketchRenderer.equals("PDF") ||
               sketchRenderer.equals("FX2D"))) {
             thisRequiresRewrite = false;
           }
+        }
+
+        if (argsContext.getChildCount() > 5) {
+          sketchOutputFilename = argsContext.getChild(6).getText();
         }
       }
 
@@ -1021,12 +1027,12 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
     String settingsOuterTemplate = indent1 + "public void settings() { %s }";
 
-    StringBuilder settingsInner = new StringBuilder();
+    StringJoiner settingsInner = new StringJoiner("\n");
 
     if (sizeRequiresRewrite) {
       if (sizeIsFullscreen) {
         String fullscreenInner = sketchRenderer == null ? "" : sketchRenderer;
-        settingsInner.append(String.format("fullScreen(%s);", fullscreenInner));
+        settingsInner.add(String.format("fullScreen(%s);", fullscreenInner));
       } else {
 
         if (sketchWidth.isEmpty() || sketchHeight.isEmpty()) {
@@ -1041,13 +1047,16 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
           argJoiner.add(sketchRenderer);
         }
 
-        settingsInner.append(String.format("size(%s);", argJoiner.toString()));
+        if (sketchOutputFilename != null) {
+          argJoiner.add(sketchOutputFilename);
+        }
+
+        settingsInner.add(String.format("size(%s);", argJoiner.toString()));
       }
     }
 
     if (pixelDensityRequiresRewrite) {
-      settingsInner.append("\n");
-      settingsInner.append(String.format("pixelDensity(%s);", pixelDensity));
+      settingsInner.add(String.format("pixelDensity(%s);", pixelDensity));
     }
 
 

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -388,6 +388,11 @@ public class ParserTests {
     expectGood("parampixeldensity");
   }
 
+  @Test
+  public void testPdfWrite() {
+    expectGood("pdfwrite");
+  }
+
   private static boolean compile(String id, String program) {
     // Create compilable AST to get syntax problems
     CompilationUnit compilableCU = JdtCompilerUtil.makeAST(

--- a/java/test/resources/pdfwrite.expected
+++ b/java/test/resources/pdfwrite.expected
@@ -1,0 +1,45 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import processing.pdf.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class pdfwrite extends PApplet {
+
+
+
+ public void setup() {
+  /* size commented out by preprocessor */;
+}
+
+ public void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  // Exit the program
+  println("Finished.");
+  exit();
+}
+
+
+    public void settings() { size(400,400,PDF,"filename.pdf"); }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "pdfwrite" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/pdfwrite.pde
+++ b/java/test/resources/pdfwrite.pde
@@ -1,0 +1,14 @@
+import processing.pdf.*;
+
+void setup() {
+  size(400, 400, PDF, "filename.pdf");
+}
+
+void draw() {
+  // Draw something good here
+  line(0, 0, width/2, height);
+
+  // Exit the program
+  println("Finished.");
+  exit();
+}


### PR DESCRIPTION
Resolve moving the PDF renderer information provided in `size()` into settings as part of preproc. Resolves #66. Note that this supersedes the fix in #64.