### PR TITLE
Warn users or provide auto-fix when `frame` is used in a sketch

### DIFF
--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1310,6 +1310,12 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
   }
 
+  static public void showChangesV4() {
+    if (!Base.isCommandLine()) {
+      Platform.openURL("https://github.com/processing/processing4/wiki/Changes-in-4.0");
+    }
+  }
+
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 

--- a/build/shared/lib/languages/PDE.properties
+++ b/build/shared/lib/languages/PDE.properties
@@ -398,6 +398,7 @@ editor.status.undef_global_var = The global variable "%s" does not exist
 editor.status.undef_class = The class "%s" does not exist
 editor.status.undef_var = The variable "%s" does not exist
 editor.status.undef_name = The name "%s" cannot be recognized
+editor.status.item_removed = "%s" was removed in this version, please use "%s" instead.
 editor.status.unterm_string_curly = String literal is not closed by a straight double quote. Curly quotes like %s won't help.
 editor.status.type_mismatch = Type mismatch, "%s" does not match with "%s"
 editor.status.unused_variable = The value of the local variable "%s" is not used

--- a/java/src/processing/mode/java/CompileErrorMessageSimplifier.java
+++ b/java/src/processing/mode/java/CompileErrorMessageSimplifier.java
@@ -242,7 +242,13 @@ public class CompileErrorMessageSimplifier {
 
       case IProblem.UndefinedName:
         if (args.length > 0) {
-          result = Language.interpolate("editor.status.undef_name", args[0]);
+          final String undefinedName = args[0];
+          if (undefinedName.equals("frame")) {
+            result = Language.interpolate("editor.status.item_removed", undefinedName, "surface");
+          }
+          else {
+            result = Language.interpolate("editor.status.undef_name", undefinedName);
+          }
         }
         break;
 

--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -247,6 +247,9 @@ public class Compiler {
                                  "displayWidth and displayHeight.");
             handleCrustyCode();
 
+          } else if (what.equals("frame")) {
+            exception.setMessage("frame was removed, use surface instead.");
+            handleCrustyCodeV4();
           } else {
             exception.setMessage("Cannot find anything " +
                                  "named \u201C" + what + "\u201D");
@@ -316,12 +319,21 @@ public class Compiler {
     return success;
   }
 
+  static protected void printCrustyCodeMessage() {
+    System.err.println("This code needs to be updated " +
+            "for this version of Processing, " +
+            "please read the Changes page on the Wiki.");
+  }
 
   static protected void handleCrustyCode() {
-    System.err.println("This code needs to be updated " +
-                       "for this version of Processing, " +
-                       "please read the Changes page on the Wiki.");
+    printCrustyCodeMessage();
     Editor.showChanges();
+  }
+
+  static protected void handleCrustyCodeV4() {
+    printCrustyCodeMessage();
+    // maybe put here an auto-fix prompt
+    Editor.showChangesV4();
   }
 
 


### PR DESCRIPTION
Work done:
- Added error message when unrecognised `frame`  occurs during compilation.
- Added translatable message about the change in editor. 
- Updated editor to show `Changes in 4.0` document.

For now I don't think I'm ready for the auto-fix, but can think about it in the future.
This is my first contribution so I'm waiting for suggestions or opinions.
