### PR TITLE
Ensure not trying to use Toolkit zoom before ready.

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -55,11 +55,13 @@ public class Preferences {
   static Map<String, String> defaults;
   static Map<String, String> table = new HashMap<>();
   static File preferencesFile;
+  private static boolean initalized = false;
 
 
 //  /** @return true if the sketchbook file did not exist */
 //  static public boolean init() {
   static public void init() {
+    initalized = true;
     // start by loading the defaults, in case something
     // important was deleted from the user prefs
     try {
@@ -260,6 +262,11 @@ public class Preferences {
   // all the information from preferences.txt
 
   static public String get(String attribute /*, String defaultValue */) {
+    if (!initalized) {
+      throw new RuntimeException(
+        "Tried reading preferences prior to initalization."
+      );
+    }
     return table.get(attribute);
   }
 

--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -129,6 +129,14 @@ public class Preferences {
   }
 
 
+  /**
+   * For testing, pretend to load preferences without a real file.
+   */
+  static public void skipInit() {
+    initalized = true;
+  }
+
+
   static void handleProxy(String protocol, String hostProp, String portProp) {
     String proxyHost = get("proxy." + protocol + ".host");
     String proxyPort = get("proxy." + protocol + ".port");

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -713,6 +713,13 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
 
   protected void buildMenuBar() {
+    Font menubarFont = new Font(
+      Preferences.get("editor.font.family"),
+      Font.PLAIN,
+      Toolkit.zoom(10)
+    );
+    UIManager.put("Menu.font", menubarFont);
+
     JMenuBar menubar = new JMenuBar();
     fileMenu = buildFileMenu();
     menubar.add(fileMenu);

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -713,13 +713,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
 
   protected void buildMenuBar() {
-    Font menubarFont = new Font(
-      Preferences.get("editor.font.family"),
-      Font.PLAIN,
-      Toolkit.zoom(10)
-    );
-    UIManager.put("Menu.font", menubarFont);
-
     JMenuBar menubar = new JMenuBar();
     fileMenu = buildFileMenu();
     menubar.add(fileMenu);

--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -829,6 +829,13 @@ public class Toolkit {
     new StringList("100%", "150%", "200%", "300%");
 
 
+  /**
+   * Calculate the desired size in pixels of an element using preferences or
+   * system zoom if preferences set to auto.
+   *
+   * @param pixels The size in pixels to scale.
+   * @return The scaled size.
+   */
   static public int zoom(int pixels) {
     if (zoom == 0) {
       zoom = parseZoom();
@@ -844,8 +851,7 @@ public class Toolkit {
   }
 
 
-  static public final int BORDER =
-    Toolkit.zoom(Platform.isMacOS() ? 20 : 13);
+  static public final int BORDER = Platform.isMacOS() ? 20 : 13;
 
 
   static public void setBorder(JComponent comp) {
@@ -903,7 +909,7 @@ public class Toolkit {
 
 
   static public boolean highResImages() {
-    return isRetina() || (zoom > 1);
+    return isRetina() || (Platform.getSystemZoom() > 1);
   }
 
 

--- a/java/test/processing/mode/java/ProcessingTestUtil.java
+++ b/java/test/processing/mode/java/ProcessingTestUtil.java
@@ -17,7 +17,7 @@ public class ProcessingTestUtil {
   static void init() {
     // noop; just causes class to be loaded
   }
-  
+
   private static final String RESOURCES = "test/resources/";
   private static final String RESOURCES_UP_DIR = "../java/test/resources";
   static final UTCompiler COMPILER;
@@ -64,9 +64,10 @@ public class ProcessingTestUtil {
 
     return normalize(out);
   }
-  
+
   static String format(final File resource)
   {
+    Preferences.skipInit();
     return format(read(resource));
   }
 


### PR DESCRIPTION
Using `Toolkit.zoom` before the preferences are ready can lead to unexpected behavior. It's best if the code that may run before that the file can load use "system zoom" (elements like splash screen). This PR adds a check for potentially using the zoom too early. Resolves #102.