### PR TITLE
Insert int after color instead of before to allow visibility modifier.

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -542,7 +542,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
    */
   public void exitColorPrimitiveType(ProcessingParser.ColorPrimitiveTypeContext ctx) {
     if (ctx.getText().equals("color")) {
-      insertBefore(ctx.start, "int");
+      insertAfter(ctx.stop, "int");
       delete(ctx.start, ctx.stop);
     }
   }

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -360,4 +360,9 @@ public class ParserTests {
     expectGood("pdfwrite");
   }
 
+  @Test
+  public void testColorReturn() {
+    expectGood("colorreturn");
+  }
+
 }

--- a/java/test/resources/colorreturn.expected
+++ b/java/test/resources/colorreturn.expected
@@ -1,0 +1,43 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class colorreturn extends PApplet {
+
+public void setup() {
+  fill(getColor());
+  noStroke();
+  /* size commented out by preprocessor */;
+  ellipseMode(CENTER);
+  ellipse(50, 50, 50, 50);
+}
+
+public int getColor() {
+  return 0xFF333333;
+}
+
+public void draw() {
+}
+
+
+    public void settings() { size(100,100); }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "colorreturn" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/colorreturn.pde
+++ b/java/test/resources/colorreturn.pde
@@ -1,0 +1,14 @@
+public void setup() {
+  fill(getColor());
+  noStroke();
+  size(100, 100);
+  ellipseMode(CENTER);
+  ellipse(50, 50, 50, 50);
+}
+
+color getColor() {
+  return #333333;
+}
+
+public void draw() {
+}


### PR DESCRIPTION
During ANTLR traversal, insert `int` after `color` instead of before. This allows visibility modifier (like `public`) to get inserted at the correct spot (prevents `int public`). Resolves #104.