### PR TITLE
New sync version of native save for JOGL.

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -38,6 +38,7 @@ import java.util.regex.Pattern;
 import processing.core.PApplet;
 import processing.core.PConstants;
 import processing.core.PGraphics;
+import processing.core.PImage;
 
 
 /**
@@ -55,6 +56,7 @@ public abstract class PGL {
   /** The PGraphics and PApplet objects using this interface */
   protected PGraphicsOpenGL graphics;
   protected PApplet sketch;
+  protected RenderCallback renderCallback;
 
   /** OpenGL thread */
   protected Thread glThread;
@@ -400,11 +402,26 @@ public abstract class PGL {
   // Initialization, finalization
 
 
-  public PGL() { }
+  public PGL() {
+    this.renderCallback = () -> {};
+  }
 
 
   public PGL(PGraphicsOpenGL pg) {
     this.graphics = pg;
+    this.renderCallback = () -> {};
+    initGraphics();
+  }
+
+
+  public PGL(PGraphicsOpenGL pg, RenderCallback newCallback) {
+    this.graphics = pg;
+    this.renderCallback = newCallback;
+    initGraphics();
+  }
+
+
+  private void initGraphics() {
     if (glColorTex == null) {
       glColorFbo = allocateIntBuffer(1);
       glColorTex = allocateIntBuffer(2);
@@ -462,6 +479,9 @@ public abstract class PGL {
 
 
   abstract protected void registerListeners();
+
+
+  abstract protected PImage screenshot();
 
 
   protected int getReadFramebuffer()  {
@@ -872,6 +892,8 @@ public abstract class PGL {
         }
       }
     }
+
+    renderCallback.onRender();
   }
 
 
@@ -2706,6 +2728,13 @@ public abstract class PGL {
 
   abstract protected Object getDerivedFont(Object font, float size);
 
+  ///////////////////////////////////////////////////////////
+
+  protected interface RenderCallback {
+
+    void onRender();
+
+  }
 
   ///////////////////////////////////////////////////////////
 

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -54,9 +54,12 @@ import com.jogamp.opengl.fixedfunc.GLMatrixFunc;
 import com.jogamp.opengl.glu.GLU;
 import com.jogamp.opengl.glu.GLUtessellator;
 import com.jogamp.opengl.glu.GLUtessellatorCallbackAdapter;
+import com.jogamp.opengl.util.awt.AWTGLReadBufferUtil;
 
+import processing.awt.PImageAWT;
 import processing.core.PApplet;
 import processing.core.PGraphics;
+import processing.core.PImage;
 import processing.core.PMatrix3D;
 import processing.core.PSurface;
 
@@ -148,6 +151,11 @@ public class PJOGL extends PGL {
     glu = new GLU();
   }
 
+  public PJOGL(PGraphicsOpenGL pg, PGL.RenderCallback callback) {
+    super(pg, callback);
+    glu = new GLU();
+  }
+
 
   @Override
   public Object getNative() {
@@ -169,6 +177,13 @@ public class PJOGL extends PGL {
 
   @Override
   protected void registerListeners() {}
+
+
+  @Override
+  protected PImage screenshot() {
+    AWTGLReadBufferUtil util = new AWTGLReadBufferUtil(capabilities.getGLProfile(), false);
+    return new PImageAWT(util.readPixelsToBufferedImage​(gl, true));
+  }
 
 
   static public void setIcon(String... icons) {
@@ -1813,8 +1828,6 @@ public class PJOGL extends PGL {
   public void blendColor(float red, float green, float blue, float alpha) {
     gl2.glBlendColor(red, green, blue, alpha);
   }
-
-  ///////////////////////////////////////////////////////////
 
   // Whole Framebuffer Operations
 


### PR DESCRIPTION
Related to #80, provides "native" saving through JOGL's internal `AWTGLReadBufferUtil`. Note that this leaves the async save in place (currently disabled by hints).