### PR TITLE
Revert to 11.0.6 to restore JOGL rendering.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -87,7 +87,7 @@
 
   <property name="jdk.train" value="11" />
   <property name="jdk.version" value="0" />
-  <property name="jdk.update" value="8" />
+  <property name="jdk.update" value="6" />
   <property name="jdk.build" value="10" />
 
   <property name="jdk.prefix" value="jdk" />


### PR DESCRIPTION
Ugghhhh 😑. Up for some discussion but going beyond 11.0.6 seems to break JOGL rendering. Resolves #121.