### PR TITLE
Zoom dialog fonts based on user scale setting

### DIFF
--- a/app/src/processing/app/platform/DefaultPlatform.java
+++ b/app/src/processing/app/platform/DefaultPlatform.java
@@ -26,9 +26,12 @@ package processing.app.platform;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.Desktop;
+import java.awt.Font;
 import java.awt.Graphics;
 import java.io.File;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.swing.Icon;
 import javax.swing.UIManager;
@@ -38,6 +41,7 @@ import com.sun.jna.Native;
 
 import processing.app.Base;
 import processing.app.Preferences;
+import processing.app.ui.Toolkit;
 
 
 /**
@@ -56,6 +60,38 @@ import processing.app.Preferences;
  * know if name is proper Java package syntax.)
  */
 public class DefaultPlatform {
+
+  private final List<String> FONT_SCALING_WIDGETS =new ArrayList<String>(){{
+    add("Button");
+    add("CheckBox");
+    add("CheckBoxMenuItem");
+    add("ComboBox");
+    add("Label");
+    add("List");
+    add("Menu");
+    add("MenuBar");
+    add("MenuItem");
+    add("OptionPane");
+    add("Panel");
+    add("PopupMenu");
+    add("ProgressBar");
+    add("RadioButton");
+    add("RadioButtonMenuItem");
+    add("ScrollPane");
+    add("TabbedPane");
+    add("Table");
+    add("TableHeader");
+    add("TextArea");
+    add("TextField");
+    add("TextPane");
+    add("TitledBorder");
+    add("ToggleButton");
+    add("ToolBar");
+    add("ToolTip");
+    add("Tree");
+    add("Viewport");
+  }};
+
   Base base;
 
   private final float ZOOM_DEFAULT_SIZING = 1;
@@ -96,6 +132,13 @@ public class DefaultPlatform {
       }
     } else {
       UIManager.setLookAndFeel(laf);
+    }
+
+    // Specify font when scaling is active.
+    if (!Preferences.getBoolean("editor.zoom.auto")) {
+      for (String widgetName : FONT_SCALING_WIDGETS) {
+        scaleDefaultFont(widgetName);
+      }
     }
   }
 
@@ -235,6 +278,23 @@ public class DefaultPlatform {
 
     @Override
     public void paintIcon(Component c, Graphics g, int x, int y) {}
+  }
+
+  /**
+   * Set the default font for the widget by the given name.
+   *
+   * @param name The name of the widget whose font will be set to a scaled version of its current
+   *    default font in the selected look and feel. This must match the system widget name like
+   *    "Button" or "CheckBox"
+   */
+  private void scaleDefaultFont(String name) {
+    String fontPropertyName = name + ".font";
+
+    Font currentFont = (Font) UIManager.get(fontPropertyName);
+    int newSize = Toolkit.zoom(currentFont.getSize());
+    Font newFont = currentFont.deriveFont(newSize);
+
+    UIManager.put(fontPropertyName, newFont);
   }
 
   /**

--- a/app/src/processing/app/platform/DefaultPlatform.java
+++ b/app/src/processing/app/platform/DefaultPlatform.java
@@ -61,36 +61,34 @@ import processing.app.ui.Toolkit;
  */
 public class DefaultPlatform {
 
-  private final List<String> FONT_SCALING_WIDGETS =new ArrayList<String>(){{
-    add("Button");
-    add("CheckBox");
-    add("CheckBoxMenuItem");
-    add("ComboBox");
-    add("Label");
-    add("List");
-    add("Menu");
-    add("MenuBar");
-    add("MenuItem");
-    add("OptionPane");
-    add("Panel");
-    add("PopupMenu");
-    add("ProgressBar");
-    add("RadioButton");
-    add("RadioButtonMenuItem");
-    add("ScrollPane");
-    add("TabbedPane");
-    add("Table");
-    add("TableHeader");
-    add("TextArea");
-    add("TextField");
-    add("TextPane");
-    add("TitledBorder");
-    add("ToggleButton");
-    add("ToolBar");
-    add("ToolTip");
-    add("Tree");
-    add("Viewport");
-  }};
+  private final String[] FONT_SCALING_WIDGETS = {
+    "Button",
+    "CheckBox",
+    "CheckBoxMenuItem",
+    "ComboBox",
+    "List",
+    "Menu",
+    "MenuBar",
+    "MenuItem",
+    "OptionPane",
+    "Panel",
+    "PopupMenu",
+    "ProgressBar",
+    "RadioButton",
+    "RadioButtonMenuItem",
+    "ScrollPane",
+    "TabbedPane",
+    "Table",
+    "TableHeader",
+    "TextArea",
+    "TextPane",
+    "TitledBorder",
+    "ToggleButton",
+    "ToolBar",
+    "ToolTip",
+    "Tree",
+    "Viewport"
+  };
 
   Base base;
 
@@ -139,6 +137,9 @@ public class DefaultPlatform {
       for (String widgetName : FONT_SCALING_WIDGETS) {
         scaleDefaultFont(widgetName);
       }
+
+      UIManager.put("Label.font", new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
+      UIManager.put("TextField.font", new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
     }
   }
 
@@ -291,8 +292,11 @@ public class DefaultPlatform {
     String fontPropertyName = name + ".font";
 
     Font currentFont = (Font) UIManager.get(fontPropertyName);
-    int newSize = Toolkit.zoom(currentFont.getSize());
+    System.out.println(currentFont);
+    float newSize = Toolkit.zoom(currentFont.getSize());
+    System.out.println(newSize);
     Font newFont = currentFont.deriveFont(newSize);
+    System.out.println(newFont);
 
     UIManager.put(fontPropertyName, newFont);
   }

--- a/app/src/processing/app/tools/CreateFont.java
+++ b/app/src/processing/app/tools/CreateFont.java
@@ -101,7 +101,7 @@ public class CreateFont extends JFrame implements Tool {
     textarea.setBackground(null);
     textarea.setEditable(false);
     textarea.setHighlighter(null);
-    textarea.setFont(new Font("Dialog", Font.PLAIN, 12));
+    textarea.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
     pain.add(textarea);
 
     // don't care about families starting with . or #
@@ -174,6 +174,8 @@ public class CreateFont extends JFrame implements Tool {
     System.arraycopy(fontList, 0, list, 0, index);
 
     fontSelector = new JList<String>(list);
+    fontSelector.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
+
     fontSelector.addListSelectionListener(new ListSelectionListener() {
         public void valueChanged(ListSelectionEvent e) {
           if (e.getValueIsAdjusting() == false) {
@@ -194,9 +196,11 @@ public class CreateFont extends JFrame implements Tool {
 
     sample = new SampleComponent(this);
 
+    Font dialogBottomFont = new Font("Dialog", Font.PLAIN, Toolkit.zoom(12));
+
     // Seems that in some instances, no default font is set
     // http://dev.processing.org/bugs/show_bug.cgi?id=777
-    sample.setFont(new Font("Dialog", Font.PLAIN, 12));
+    sample.setFont(dialogBottomFont);
 
     pain.add(sample);
 
@@ -204,8 +208,13 @@ public class CreateFont extends JFrame implements Tool {
     pain.add(new Box.Filler(d2, d2, d2));
 
     JPanel panel = new JPanel();
-    panel.add(new JLabel(Language.text("create_font.size") + ":" ));
+
+    JLabel sizeLabel = new JLabel(Language.text("create_font.size") + ":" );
+    sizeLabel.setFont(dialogBottomFont);
+    panel.add(sizeLabel);
+
     sizeSelector = new JTextField(" 48 ");
+    sizeSelector.setFont(dialogBottomFont);
     sizeSelector.getDocument().addDocumentListener(new DocumentListener() {
         public void insertUpdate(DocumentEvent e) { update(); }
         public void removeUpdate(DocumentEvent e) { update(); }
@@ -214,6 +223,7 @@ public class CreateFont extends JFrame implements Tool {
     panel.add(sizeSelector);
 
     smoothBox = new JCheckBox(Language.text("create_font.smooth"));
+    smoothBox.setFont(dialogBottomFont);
     smoothBox.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           smooth = smoothBox.isSelected();
@@ -232,6 +242,7 @@ public class CreateFont extends JFrame implements Tool {
 //    allBox.setSelected(all);
 //    panel.add(allBox);
     charsetButton = new JButton(Language.text("create_font.characters"));
+    charsetButton.setFont(dialogBottomFont);
     charsetButton.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
         //showCharacterList();
@@ -282,7 +293,7 @@ public class CreateFont extends JFrame implements Tool {
     //System.out.println(getPreferredSize());
 
     // do this after pack so it doesn't affect layout
-    sample.setFont(new Font(list[0], Font.PLAIN, 48));
+    sample.setFont(new Font(list[0], Font.PLAIN, Toolkit.zoom(48)));
 
     fontSelector.setSelectedIndex(0);
 
@@ -512,7 +523,7 @@ class CharacterSelector extends JFrame {
     textarea.setBackground(null);
     textarea.setEditable(false);
     textarea.setHighlighter(null);
-    textarea.setFont(new Font("Dialog", Font.PLAIN, 12));
+    textarea.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
     pain.add(textarea);
 
     ActionListener listener = new ActionListener() {

--- a/app/src/processing/app/tools/CreateFont.java
+++ b/app/src/processing/app/tools/CreateFont.java
@@ -45,6 +45,7 @@ import java.util.*;
 import javax.swing.*;
 import javax.swing.border.*;
 import javax.swing.event.*;
+import javax.swing.UIManager;
 
 
 /**
@@ -101,7 +102,7 @@ public class CreateFont extends JFrame implements Tool {
     textarea.setBackground(null);
     textarea.setEditable(false);
     textarea.setHighlighter(null);
-    textarea.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
+    textarea.setFont(new Font("Dialog", Font.PLAIN, 12));
     pain.add(textarea);
 
     // don't care about families starting with . or #
@@ -174,8 +175,6 @@ public class CreateFont extends JFrame implements Tool {
     System.arraycopy(fontList, 0, list, 0, index);
 
     fontSelector = new JList<String>(list);
-    fontSelector.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
-
     fontSelector.addListSelectionListener(new ListSelectionListener() {
         public void valueChanged(ListSelectionEvent e) {
           if (e.getValueIsAdjusting() == false) {
@@ -196,11 +195,9 @@ public class CreateFont extends JFrame implements Tool {
 
     sample = new SampleComponent(this);
 
-    Font dialogBottomFont = new Font("Dialog", Font.PLAIN, Toolkit.zoom(12));
-
     // Seems that in some instances, no default font is set
     // http://dev.processing.org/bugs/show_bug.cgi?id=777
-    sample.setFont(dialogBottomFont);
+    sample.setFont(new Font("Dialog", Font.PLAIN, 12));
 
     pain.add(sample);
 
@@ -208,13 +205,8 @@ public class CreateFont extends JFrame implements Tool {
     pain.add(new Box.Filler(d2, d2, d2));
 
     JPanel panel = new JPanel();
-
-    JLabel sizeLabel = new JLabel(Language.text("create_font.size") + ":" );
-    sizeLabel.setFont(dialogBottomFont);
-    panel.add(sizeLabel);
-
+    panel.add(new JLabel(Language.text("create_font.size") + ":" ));
     sizeSelector = new JTextField(" 48 ");
-    sizeSelector.setFont(dialogBottomFont);
     sizeSelector.getDocument().addDocumentListener(new DocumentListener() {
         public void insertUpdate(DocumentEvent e) { update(); }
         public void removeUpdate(DocumentEvent e) { update(); }
@@ -223,7 +215,6 @@ public class CreateFont extends JFrame implements Tool {
     panel.add(sizeSelector);
 
     smoothBox = new JCheckBox(Language.text("create_font.smooth"));
-    smoothBox.setFont(dialogBottomFont);
     smoothBox.addActionListener(new ActionListener() {
         public void actionPerformed(ActionEvent e) {
           smooth = smoothBox.isSelected();
@@ -242,7 +233,6 @@ public class CreateFont extends JFrame implements Tool {
 //    allBox.setSelected(all);
 //    panel.add(allBox);
     charsetButton = new JButton(Language.text("create_font.characters"));
-    charsetButton.setFont(dialogBottomFont);
     charsetButton.addActionListener(new ActionListener() {
       public void actionPerformed(ActionEvent e) {
         //showCharacterList();
@@ -293,7 +283,7 @@ public class CreateFont extends JFrame implements Tool {
     //System.out.println(getPreferredSize());
 
     // do this after pack so it doesn't affect layout
-    sample.setFont(new Font(list[0], Font.PLAIN, Toolkit.zoom(48)));
+    sample.setFont(new Font(list[0], Font.PLAIN, 48));
 
     fontSelector.setSelectedIndex(0);
 
@@ -523,7 +513,7 @@ class CharacterSelector extends JFrame {
     textarea.setBackground(null);
     textarea.setEditable(false);
     textarea.setHighlighter(null);
-    textarea.setFont(new Font("Dialog", Font.PLAIN, Toolkit.zoom(12)));
+    textarea.setFont(new Font("Dialog", Font.PLAIN, 12));
     pain.add(textarea);
 
     ActionListener listener = new ActionListener() {

--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -839,6 +839,7 @@ public class Toolkit {
   static public int zoom(int pixels) {
     if (zoom == 0) {
       zoom = parseZoom();
+      System.out.println(zoom);
     }
     // Deal with 125% scaling badness
     // https://github.com/processing/processing/issues/4902

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -1750,8 +1750,11 @@ public class JavaEditor extends Editor {
                                     + " changes in your sketch.<br />"
                                     + "&nbsp;&nbsp;&nbsp; Do you want to save it before"
                                     + " running? </body></html>");
-          label.setFont(new Font(label.getFont().getName(),
-                                 Font.PLAIN, label.getFont().getSize() + 1));
+          label.setFont(new Font(
+              label.getFont().getName(),
+              Font.PLAIN,
+              Toolkit.zoom(label.getFont().getSize() + 1)
+          ));
           panelLabel.add(label);
           panelMain.add(panelLabel);
           final JCheckBox dontRedisplay = new JCheckBox("Remember this decision");


### PR DESCRIPTION
Updates the default fonts after applying the look and feel to allow users' scale settings to zoom on all dialogs, not just main editor window. This helps with accessibility. Resolves #111.