### PR TITLE
correct alphabetical order for language list

### DIFF
--- a/build/shared/lib/languages/languages.txt
+++ b/build/shared/lib/languages/languages.txt
@@ -7,8 +7,8 @@
 
 ar  # Arabic
 de  # German, Deutsch
-en  # English, English
 el  # Greek
+en  # English, English
 es  # Spanish
 fr  # French, Français, Langue française
 it  # Italiano, Italian


### PR DESCRIPTION
The order of English was wrong with that of Greek. In the future I intend to add Esperanto(EO), and this generates ambiguity.