### PR TITLE
Fix undo/redo when switching between tabs

### DIFF
--- a/app/src/processing/app/SketchCode.java
+++ b/app/src/processing/app/SketchCode.java
@@ -25,6 +25,7 @@
 package processing.app;
 
 import java.io.*;
+import java.util.Stack;
 
 import javax.swing.text.BadLocationException;
 import javax.swing.text.Document;
@@ -64,7 +65,15 @@ public class SketchCode {
    * Editor.undo will be set to this object when this code is the tab
    * that's currently the front.
    */
-  private UndoManager undo = new UndoManager();
+  private final UndoManager undo = new UndoManager();
+
+  /**
+   * Caret positions for this tab.
+   * Editor.caretUndoStack and Editor.caretRedoStack will be set to these
+   * when this code is the tab that's currently the front.
+   */
+  private final Stack<Integer> caretUndoStack = new Stack<>();
+  private final Stack<Integer> caretRedoStack = new Stack<>();
 
   /** What was on top of the undo stack when last saved. */
 //  private UndoableEdit lastEdit;
@@ -238,6 +247,13 @@ public class SketchCode {
     return undo;
   }
 
+  public Stack<Integer> getCaretRedoStack() {
+    return caretRedoStack;
+  }
+
+  public Stack<Integer> getCaretUndoStack() {
+    return caretUndoStack;
+  }
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -138,8 +138,11 @@ public abstract class Editor extends JFrame implements RunnerListener {
   /** Menu Actions updated on the opening of the edit menu. */
   protected List<UpdatableAction> editMenuUpdatable = new ArrayList<>();
 
-  /** The currently selected tab's undo manager */
+  /** The currently selected tab's undo manager and caret positions*/
   private UndoManager undo;
+  // maintain caret position during undo operations
+  private Stack<Integer> caretUndoStack = new Stack<>();
+  private Stack<Integer> caretRedoStack = new Stack<>();
   // used internally for every edit. Groups hotkey-event text manipulations and
   // groups  multi-character inputs into a single undos.
   private CompoundEdit compoundEdit;
@@ -148,9 +151,6 @@ public abstract class Editor extends JFrame implements RunnerListener {
   private TimerTask endUndoEvent;
   // true if inserting text, false if removing text
   private boolean isInserting;
-  // maintain caret position during undo operations
-  private final Stack<Integer> caretUndoStack = new Stack<>();
-  private final Stack<Integer> caretRedoStack = new Stack<>();
 
   private FindReplace find;
   JMenu toolsMenu;
@@ -1904,7 +1904,12 @@ public abstract class Editor extends JFrame implements RunnerListener {
 //    textarea.requestFocus();  // get the caret blinking
     textarea.requestFocusInWindow();  // required for caret blinking
 
+    // end edits in the previous tab
+    endTextEditHistory();
+    // update the UndoManager and caret positions to the selected tab
     this.undo = code.getUndo();
+    caretUndoStack = code.getCaretUndoStack();
+    caretRedoStack = code.getCaretRedoStack();
     undoAction.updateUndoState();
     redoAction.updateRedoState();
   }


### PR DESCRIPTION
Switching a code tab never stops the current text edit history, resulting in undo/redo making changes to tabs other than the current one. 
There is also only one caret undo/redo stack per Editor, resulting in an incorrect caret placement when switching between tabs and undoing / redoing.
This was mentioned in [this comment](https://github.com/processing/processing/issues/4775#issuecomment-569511757) in issue processing/processing/issues/4775.

I added `endTextEditHistory();` to `Editor::setCode` and `caretUndoStack` and `caretRedoStack` to `SketchCode` so every tab has a unique set of caret positions. Editor's caret undo/redo stacks are changed in `setCode` according to current code tab the same way it currently works for `Editor.undo`.

This is my first time making a Pull Request to a public repository so any assistance would be appreciated.