### PR TITLE
Updated batik URL

### DIFF
--- a/java/libraries/svg/build.xml
+++ b/java/libraries/svg/build.xml
@@ -6,7 +6,7 @@
     <delete file="library/svg.jar" />
   </target>
 
-  <property name="batik.version" value="1.13" />
+  <property name="batik.version" value="1.14" />
   <!-- the .zip file to be downloaded -->
   <property name="batik.zip" value="batik-bin-${batik.version}.zip" />
   <!-- the .jar file that's the actual dependency -->
@@ -14,7 +14,7 @@
 
   <!-- URL for the version of Batik currently supported by this library. -->
   <property name="batik.url"
-            value="https://apache.osuosl.org/xmlgraphics/batik/binaries/${batik.zip}" />
+            value="https://archive.apache.org/dist/xmlgraphics/batik/binaries/${batik.zip}" />
 
   <!-- Storing a "local" copy in case the original link goes dead. When updating
        releases, please upload the new version to download.processing.org. -->


### PR DESCRIPTION
Fixes #179 

The previous (current) URL does not host batik anymore. 
URL has been updated to point to the Apache archive: https://archive.apache.org/dist/xmlgraphics/batik/binaries/

Batik version also updated from 1.13 -> 1.14