### PR TITLE
Bugfix mouseReleased

### DIFF
--- a/core/src/processing/awt/PSurfaceAWT.java
+++ b/core/src/processing/awt/PSurfaceAWT.java
@@ -1276,6 +1276,22 @@ public class PSurfaceAWT extends PSurfaceNone {
     // the 'amount' is the number of button clicks for a click event,
     // or the number of steps/clicks on the wheel for a mouse wheel event.
     int peCount = nativeEvent.getClickCount();
+    int peButton =  nativeEvent.getButton();
+
+    // Switching to getModifiersEx() for 4.0a2 because of Java 9 deprecation.
+    // Had trouble with this in the past and rolled it back because it was
+    // optional at the time. This time around, just need to iron out the issue.
+    // http://code.google.com/p/processing/issues/detail?id=1294
+    // http://code.google.com/p/processing/issues/detail?id=1332
+    final int modifiers = nativeEvent.getModifiersEx();
+
+    // for macOS, where ctrl-click is traditionally recognized as a right click
+    final int ctrl_click = InputEvent.CTRL_DOWN_MASK;
+    if ( (modifiers & ctrl_click) != 0) {
+      if (peButton == PConstants.MOUSE_LEFT && PApplet.platform == PConstants.MACOS) {
+        peButton = PConstants.MOUSE_RIGHT;
+      }
+    } 
 
     int peAction = 0;
     switch (nativeEvent.getID()) {
@@ -1300,38 +1316,13 @@ public class PSurfaceAWT extends PSurfaceNone {
     case java.awt.event.MouseEvent.MOUSE_EXITED:
       peAction = MouseEvent.EXIT;
       break;
-    //case java.awt.event.MouseWheelEvent.WHEEL_UNIT_SCROLL:
     case java.awt.event.MouseEvent.MOUSE_WHEEL:
       peAction = MouseEvent.WHEEL;
-      /*
-      if (preciseWheelMethod != null) {
-        try {
-          peAmount = ((Double) preciseWheelMethod.invoke(nativeEvent, (Object[]) null)).floatValue();
-        } catch (Exception e) {
-          preciseWheelMethod = null;
-        }
-      }
-      */
       peCount = ((MouseWheelEvent) nativeEvent).getWheelRotation();
       break;
     }
 
-    // Switching to getModifiersEx() for 4.0a2 because of Java 9 deprecation.
-    // Had trouble with this in the past and rolled it back because it was
-    // optional at the time. This time around, just need to iron out the issue.
-    // http://code.google.com/p/processing/issues/detail?id=1294
-    // http://code.google.com/p/processing/issues/detail?id=1332
-    int modifiers = nativeEvent.getModifiersEx();
-
-    int peButton = 0;
-    if ((modifiers & InputEvent.BUTTON1_DOWN_MASK) != 0) {
-      peButton = PConstants.LEFT;
-    } else if ((modifiers & InputEvent.BUTTON2_DOWN_MASK) != 0) {
-      peButton = PConstants.CENTER;
-    } else if ((modifiers & InputEvent.BUTTON3_DOWN_MASK) != 0) {
-      peButton = PConstants.RIGHT;
-    }
-
+    
     sketch.postEvent(new MouseEvent(nativeEvent, nativeEvent.getWhen(),
                                     peAction, modifiers,
                                     nativeEvent.getX() / windowScaleFactor,

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2670,27 +2670,7 @@ public class PApplet implements PConstants {
       mouseY = event.getY();
     }
 
-    int button = event.getButton();
-
-    // If running on Mac OS, allow ctrl-click as right mouse.
-    if (PApplet.platform == PConstants.MACOS && event.getButton() == PConstants.LEFT) {
-      if (action == MouseEvent.PRESS && event.isControlDown()) {
-        macosxLeftButtonWithCtrlPressed = true;
-      }
-      if (macosxLeftButtonWithCtrlPressed) {
-        button = PConstants.RIGHT;
-        event = new MouseEvent(event.getNative(), event.getMillis(),
-                               event.getAction(), event.getModifiers(),
-                               event.getX(), event.getY(),
-                               button, event.getCount());
-      }
-      if (action == MouseEvent.RELEASE) {
-        macosxLeftButtonWithCtrlPressed = false;
-      }
-    }
-
-    // Get the (already processed) button code
-    mouseButton = button;
+    mouseButton = event.getButton();
 
     /*
     // Compatibility for older code (these have AWT object params, not P5)

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -462,6 +462,12 @@ public interface PConstants {
   int CONTROL   = KeyEvent.VK_CONTROL;
   int SHIFT     = KeyEvent.VK_SHIFT;
 
+  // mouse buttons
+
+  int MOUSE_LEFT    = 1;
+  int MOUSE_MIDDLE  = 2;
+  int MOUSE_RIGHT   = 3;
+
 
   // orientations (only used on Android, ignored on desktop)
 

--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1093,26 +1093,21 @@ public class PSurfaceJOGL implements PSurface {
   protected void nativeMouseEvent(com.jogamp.newt.event.MouseEvent nativeEvent,
                                   int peAction) {
     int modifiers = nativeEvent.getModifiers();
-    /*
-    int peModifiers = modifiers &
-                      (InputEvent.SHIFT_MASK |
-                       InputEvent.CTRL_MASK |
-                       InputEvent.META_MASK |
-                       InputEvent.ALT_MASK);
-     */
 
     int peButton = 0;
     switch (nativeEvent.getButton()) {
       case com.jogamp.newt.event.MouseEvent.BUTTON1:
-        peButton = PConstants.LEFT;
+        peButton = PConstants.MOUSE_LEFT;
         break;
       case com.jogamp.newt.event.MouseEvent.BUTTON2:
-        peButton = PConstants.CENTER;
+        peButton = PConstants.MOUSE_MIDDLE;
         break;
       case com.jogamp.newt.event.MouseEvent.BUTTON3:
-        peButton = PConstants.RIGHT;
+        peButton = PConstants.MOUSE_RIGHT;
         break;
     }
+
+
 
     int peCount = 0;
     if (peAction == MouseEvent.WHEEL) {
@@ -1127,6 +1122,9 @@ public class PSurfaceJOGL implements PSurface {
     int scale;
     if (PApplet.platform == PConstants.MACOS) {
       scale = (int) getCurrentPixelScale();
+      if (peButton == PConstants.MOUSE_LEFT && nativeEvent.isControlDown()) {
+        peButton = PConstants.MOUSE_RIGHT;
+      }
     } else {
       scale = (int) getPixelScale();
     }

--- a/java/libraries/svg/build.xml
+++ b/java/libraries/svg/build.xml
@@ -6,7 +6,7 @@
     <delete file="library/svg.jar" />
   </target>
 
-  <property name="batik.version" value="1.13" />
+  <property name="batik.version" value="1.14" />
   <!-- the .zip file to be downloaded -->
   <property name="batik.zip" value="batik-bin-${batik.version}.zip" />
   <!-- the .jar file that's the actual dependency -->
@@ -14,7 +14,7 @@
 
   <!-- URL for the version of Batik currently supported by this library. -->
   <property name="batik.url"
-            value="https://apache.osuosl.org/xmlgraphics/batik/binaries/${batik.zip}" />
+            value="https://archive.apache.org/dist/xmlgraphics/batik/binaries/${batik.zip}" />
 
   <!-- Storing a "local" copy in case the original link goes dead. When updating
        releases, please upload the new version to download.processing.org. -->


### PR DESCRIPTION
This should address #181 where `mouseReleased()` misreports all events with a `mouseButton` value of `0`

As well, `ctrl-leftClick` for macOS users should be properly recognized as a secondary(right) click.

I also updated PConstants to include `MOUSE_LEFT, MOUSE_MIDDLE, MOUSE_RIGHT` instead of the `LEFT,CENTER,RIGHT` constants. The current constants are associated with keyboard events such as `KeyEvent.VK_LEFT` and returned values that didn't make much sense, e.g. left click returning a mouseButton value of 37?

In short, mouseButton returns 1,2,3 (leftclick ,middleclick, rightclick).

As far as I can tell on my end, everything behaves properly for sketches using the default renderer, P2D, and P3D. I've only tested this on macOS (11.2.3). Would love it if anyone out there using Linux/Windows could confirm things behave on their end.