### PR TITLE
Fixed constructor for classes, name for fields, and made 'other' type…

### DIFF
--- a/doclet/ReferenceGenerator/processingrefBuild.sh
+++ b/doclet/ReferenceGenerator/processingrefBuild.sh
@@ -11,17 +11,6 @@ REFERENCES_OUT_PATH=../../../processing-website/content/references/translations/
 echo "[REFERENCE GENERATOR] Source Path :: $PROCESSING_SRC_PATH"
 echo "[REFERENCE GENERATOR] Library Path :: $PROCESSING_LIB_PATH"
 
-
-echo "[REFERENCE GENERATOR] Removing previous version of the ref..."
-rm -rf $REFERENCES_OUT_PATH
-mkdir $REFERENCES_OUT_PATH
-mkdir $REFERENCES_OUT_PATH/processing
-mkdir $REFERENCES_OUT_PATH/io
-mkdir $REFERENCES_OUT_PATH/net
-mkdir $REFERENCES_OUT_PATH/serial
-mkdir $REFERENCES_OUT_PATH/sound
-mkdir $REFERENCES_OUT_PATH/video
-
 echo "[REFERENCE GENERATOR] Generating new javadocs..."
 javadoc -doclet ProcessingWeblet \
         -docletpath "bin/:lib/org.json.jar" \

--- a/doclet/ReferenceGenerator/src/writers/ClassWriter.java
+++ b/doclet/ReferenceGenerator/src/writers/ClassWriter.java
@@ -137,6 +137,9 @@ public class ClassWriter extends BaseWriter {
 			{
 				constructor = constructor.substring(0, constructor.length()-2) + ")";
 			}
+			else {
+				constructor += ")";
+			}
 			constructors.add(constructor);
 		}
 		return constructors;

--- a/doclet/ReferenceGenerator/src/writers/FieldWriter.java
+++ b/doclet/ReferenceGenerator/src/writers/FieldWriter.java
@@ -22,16 +22,22 @@ public class FieldWriter extends BaseWriter {
 	
 	public static void write(HashMap<String, String> vars, FieldDoc doc, String classname) throws IOException
 	{
-		String filename = getAnchor(doc);
 		TemplateWriter templateWriter = new TemplateWriter();
 
 		JSONObject fieldJSON = new JSONObject();
 
+		String fieldName;
+		if (getName(doc).contains("[]"))  {
+			fieldName = getName(doc).replace("[]", "");
+		} else {
+			fieldName = getName(doc);
+		}
+
 		String fileName;
 		if (classname != "") {
-			fileName = jsonDir + classname + "_" + getName(doc) + ".json";
+			fileName = jsonDir + classname + "_" + fieldName + ".json";
 		} else {
-			fileName = jsonDir + getName(doc) + ".json";
+			fileName = jsonDir + fieldName + ".json";
 		}
 
 		Tag[] tags = doc.tags(Shared.i().getWebrefTagName());
@@ -40,7 +46,6 @@ public class FieldWriter extends BaseWriter {
 
 		try
 		{
-			fieldJSON.put("type", "field");
 			fieldJSON.put("description", getWebDescriptionFromSource(doc));
 			fieldJSON.put("brief", getWebBriefFromSource(doc));
 			fieldJSON.put("category", category);
@@ -49,8 +54,9 @@ public class FieldWriter extends BaseWriter {
 			fieldJSON.put("related", getRelated(doc));
 		
 			if(Shared.i().isRootLevel(doc.containingClass())){
-				fieldJSON.put("classname", "");
+				fieldJSON.put("type", "other");
 			} else {
+				fieldJSON.put("type", "field");
 				fieldJSON.put("classanchor", getLocalAnchor(doc.containingClass()));
 				fieldJSON.put("parameters", getParentParam(doc));		
 				String syntax = templateWriter.writePartial("field.syntax.partial", getSyntax(doc));


### PR DESCRIPTION
This PR:

1. fixes missing `)` in constructor name for classes
2. removes `[]` in field names
3. changes type `field` to type `other` for references that don't belong to classes (such as constants, functions and fields)
4. adjusts `processingrefBuild.sh` so that it overwrites individual files instead of folders