### PR TITLE
Changes to doclet and code comments

### DIFF
--- a/core/src/processing/awt/PGraphicsJava2D.java
+++ b/core/src/processing/awt/PGraphicsJava2D.java
@@ -1029,7 +1029,7 @@ public class PGraphicsJava2D extends PGraphics {
    *
    *
    * @webref Rendering
-   * @webBrief Blends the pixels in the display window according to a defined mode. 
+   * @webBrief Blends the pixels in the display window according to a defined mode
    * @param mode the blending mode to use
    */
   @Override

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -5530,9 +5530,9 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will be
    * returned and an error message will be printed to the console. The error
-   * message does not halt the program, however the null value may cause a
+   * message does not halt the program, however the <b>null</b> value may cause a
    * NullPointerException if your code does not check whether the value returned
-   * is null.<br />
+   * is <b>null</b>.<br />
    * <br />
    * The <b>extension</b> parameter is used to determine the image type in cases
    * where the image filename does not end with a proper extension. Specify the
@@ -5721,13 +5721,13 @@ public class PApplet implements PConstants {
 
   /**
    * Takes a String, parses its contents, and returns an XML object. If the
-   * String does not contain XML data or cannot be parsed, a null value is
+   * String does not contain XML data or cannot be parsed, a <b>null</b> value is
    * returned.<br />
    * <br />
    * <b>parseXML()</b> is most useful when pulling data dynamically, such as
    * from third-party APIs. Normally, API results would be saved to a String,
    * and then can be converted to a structured XML object using
-   * <b>parseXML()</b>. Be sure to check if null is returned before performing
+   * <b>parseXML()</b>. Be sure to check if <b>null</b> is returned before performing
    * operations on the new XML object, in case the String content could not be
    * parsed.<br />
    * <br />
@@ -6185,9 +6185,9 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will be
    * returned and an error message will be printed to the console. The error
-   * message does not halt the program, however the null value may cause a
+   * message does not halt the program, however the <b>null</b> value may cause a
    * NullPointerException if your code does not check whether the value returned
-   * is null.<br />
+   * is <b>null</b>.<br />
    * <br />
    * Use <b>createFont()</b> (instead of <b>loadFont()</b>) to enable vector
    * data to be used with the default renderer setting. This can be helpful when
@@ -6318,7 +6318,7 @@ public class PApplet implements PConstants {
   /**
    * Open a platform-specific file chooser dialog to select a file for input.
    * After the selection is made, the selected File will be passed to the
-   * 'callback' function. If the dialog is closed or canceled, null will be sent
+   * 'callback' function. If the dialog is closed or canceled, <b>null</b> will be sent
    * to the function, so that the program is not waiting for additional input.
    * The callback is necessary because of how threading works.
    *
@@ -6384,7 +6384,7 @@ public class PApplet implements PConstants {
   /**
    * Opens a platform-specific file chooser dialog to select a file for output.
    * After the selection is made, the selected File will be passed to the
-   * 'callback' function. If the dialog is closed or canceled, null will be sent
+   * 'callback' function. If the dialog is closed or canceled, <b>null</b> will be sent
    * to the function, so that the program is not waiting for additional input.
    * The callback is necessary because of how threading works.
    *
@@ -6912,7 +6912,7 @@ public class PApplet implements PConstants {
    * - The full path to a file to be opened locally (when running as an
    * application)<br />
    * <br />
-   * If the requested item doesn't exist, null is returned. If not online,
+   * If the requested item doesn't exist, <b>null</b> is returned. If not online,
    * this will also check to see if the user is asking for a file whose name
    * isn't properly capitalized. If capitalization is different, an error
    * will be printed to the console. This helps prevent issues that appear
@@ -7183,9 +7183,9 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will be
    * returned and an error message will be printed to the console. The error
-   * message does not halt the program, however the null value may cause a
+   * message does not halt the program, however the <b>null</b> value may cause a
    * NullPointerException if your code does not check whether the value returned
-   * is null.<br />
+   * is <b>null</b>.<br />
    *
    * @webref input:files
    * @webBrief Reads the contents of a file or url and places it in a byte
@@ -7401,9 +7401,9 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will be
    * returned and an error message will be printed to the console. The error
-   * message does not halt the program, however the null value may cause a
+   * message does not halt the program, however the <b>null</b> value may cause a
    * NullPointerException if your code does not check whether the value returned
-   * is null.<br />
+   * is <b>null</b>.<br />
    * <br />
    * Starting with Processing release 0134, all files loaded and saved by the
    * Processing API use UTF-8 encoding. In previous releases, the default
@@ -9149,12 +9149,12 @@ public class PApplet implements PConstants {
    *
    * This function is used to apply a regular expression to a piece of text, and
    * return matching groups (elements found inside parentheses) as a String
-   * array. If there are no matches, a null value will be returned. If no groups
+   * array. If there are no matches, a <b>null</b> value will be returned. If no groups
    * are specified in the regular expression, but the sequence matches, an array
    * of length 1 (with the matched text as the first element of the array) will
    * be returned.<br />
    * <br />
-   * To use the function, first check to see if the result is null. If the
+   * To use the function, first check to see if the result is <b>null</b>. If the
    * result is null, then the sequence did not match at all. If the sequence did
    * match, an array is returned.<br />
    * <br />
@@ -9173,7 +9173,7 @@ public class PApplet implements PConstants {
    * @webref data:string_functions
    * @webBrief The match() function is used to apply a regular expression to a
    *           piece of text, and return matching groups (elements found inside
-   *           parentheses) as a String array. No match will return null.
+   *           parentheses) as a <b>String</b> array. No match will return <b>null</b>.
    * @param str
    *          the String to be searched
    * @param regexp
@@ -9203,12 +9203,12 @@ public class PApplet implements PConstants {
    *
    * This function is used to apply a regular expression to a piece of text, and
    * return a list of matching groups (elements found inside parentheses) as a
-   * two-dimensional String array. If there are no matches, a null value will be
+   * two-dimensional String array. If there are no matches, a <b>null</b> value will be
    * returned. If no groups are specified in the regular expression, but the
    * sequence matches, a two dimensional array is still returned, but the second
    * dimension is only of length one.<br />
    * <br />
-   * To use the function, first check to see if the result is null. If the
+   * To use the function, first check to see if the result is <b>null</b>. If the
    * result is null, then the sequence did not match at all. If the sequence did
    * match, a 2D array is returned.<br />
    * <br />
@@ -11524,9 +11524,9 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will
    * be returned and an error message will be printed to the console.
-   * The error message does not halt the program, however the null value
+   * The error message does not halt the program, however the <b>null</b> value
    * may cause a NullPointerException if your code does not check whether
-   * the value returned is null.<br />
+   * the value returned is <b>null</b>.<br />
    *
    * @webref shape
    * @webBrief Loads geometry into a variable of type <b>PShape</b>.
@@ -11615,7 +11615,7 @@ public class PApplet implements PConstants {
    * be returned and an error message will be printed to the console.
    * The error message does not halt the program, however the null
    * value may cause a NullPointerException if your code does not check
-   * whether the value returned is null.<br />
+   * whether the value returned is <b>null</b>.<br />
    *
    *
    * @webref rendering:shaders

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -644,8 +644,8 @@ public class PApplet implements PConstants {
   /**
    *
    * Confirms if a Processing program is "focused", meaning that it is active
-   * and will accept input from mouse or keyboard. This variable is "true" if
-   * it is focused and "false" if not.
+   * and will accept input from mouse or keyboard. This variable is <b>true</b> if
+   * it is focused and <b>false</b> if not.
    *
    * @webref environment
    * @webBrief Confirms if a Processing program is "focused".
@@ -1077,23 +1077,23 @@ public class PApplet implements PConstants {
   * pixels on high resolutions screens like Apple Retina
   * displays and Windows High-DPI displays. This function
   * can only be run once within a program and it must be
-  * used right after size() in a program without a setup()
-  * and used within setup() when a program has one. The
-  * pixelDensity() should only be used with hardcoded
+  * used right after <b>size()</b> in a program without a <b>setup()</b>
+  * and used within <b>setup()</b> when a program has one. The
+  * <b>pixelDensity()</b> should only be used with hardcoded
   * numbers (in almost all cases this number will be 2)
-  * or in combination with displayDensity() as in the
+  * or in combination with <b>displayDensity()</b> as in the
   * third example above.
   *
   * When the pixel density is set to more than 1, it
   * changes all of the pixel operations including the way
-  * get(), set(), blend(), copy(), and updatePixels()
-  * all work. See the reference for pixelWidth and
+  * <b>get()</b>, <b>set()</b>, <b>blend()</b>, <b>copy()</b>, and <b>updatePixels()</b>
+  * all work. See the reference for <b>pixelWidth</b> and
   * pixelHeight for more information.
   *
-  * To use variables as the arguments to pixelDensity()
-  * function, place the pixelDensity() function within
-  * the settings() function. There is more information
-  * about this on the settings() reference page.
+  * To use variables as the arguments to <b>pixelDensity()</b>
+  * function, place the <b>pixelDensity()</b> function within
+  * the <b>settings()</b> function. There is more information
+  * about this on the <b>settings()</b> reference page.
   *
   * @webref environment
   * @webBrief It makes it possible for Processing to render using all of the
@@ -1151,36 +1151,36 @@ public class PApplet implements PConstants {
 
   /**
    * Draws all geometry with smooth (anti-aliased) edges.
-   * This behavior is the default, so smooth() only needs
+   * This behavior is the default, so <b>smooth()</b> only needs
    * to be used when a program needs to set the smoothing
    * in a different way. The level parameter increases
    * the amount of smoothness. This is the level of over
    * sampling applied to the graphics buffer.
    *
-   * With the P2D and P3D renderers, smooth(2) is the
+   * With the P2D and P3D renderers, <b>smooth(2)</b> is the
    * default, this is called "2x anti-aliasing." The code
-   * smooth(4) is used for 4x anti-aliasing and smooth(8)
+   * <b>smooth(4)</b> is used for 4x anti-aliasing and <b>smooth(8)</b>
    * is specified for "8x anti-aliasing." The maximum
    * anti-aliasing level is determined by the hardware of
-   * the machine that is running the software, so smooth(4)
-   * and smooth(8) will not work with every computer.
+   * the machine that is running the software, so <b>smooth(4)</b>
+   * and <b>smooth(8)</b> will not work with every computer.
    *
-   * The default renderer uses smooth(3) by default. This
+   * The default renderer uses <b>smooth(3)</b> by default. This
    * is bicubic smoothing. The other option for the default
-   * renderer is smooth(2), which is bilinear smoothing.
+   * renderer is <b>smooth(2)</b>, which is bilinear smoothing.
    *
-   * With Processing 3.0, smooth() is different than before.
-   * It was common to use smooth() and noSmooth() to turn on
+   * With Processing 3.0, <b>smooth()</b> is different than before.
+   * It was common to use <b>smooth()</b> and <b>noSmooth()</b> to turn on
    * and off antialiasing within a sketch. Now, because of
-   * how the software has changed, smooth() can only be set
+   * how the software has changed, <b>smooth()</b> can only be set
    * once within a sketch. It can be used either at the top
-   * of a sketch without a setup(), or after the size()
-   * function when used in a sketch with setup(). The
-   * noSmooth() function also follows the same rules.
+   * of a sketch without a <b>setup()</b>, or after the <b>size()</b>
+   * function when used in a sketch with <b>setup()</b>. The
+   * <b>noSmooth()</b> function also follows the same rules.
    *
-   * When smooth() is used with a PGraphics object, it should
+   * When <b>smooth()</b> is used with a PGraphics object, it should
    * be run right after the object is created with
-   * createGraphics(), as shown in the Reference in the third
+   * <b>createGraphics()</b>, as shown in the Reference in the third
    * example.
    *
    * @webref environment
@@ -1200,13 +1200,13 @@ public class PApplet implements PConstants {
    * Draws all geometry and fonts with jagged (aliased)
    * edges and images with hard edges between the pixels
    * when enlarged rather than interpolating pixels. Note
-   * that smooth() is active by default, so it is necessary
-   * to call noSmooth() to disable smoothing of geometry,
+   * that <b>smooth()</b> is active by default, so it is necessary
+   * to call <b>noSmooth()<b> to disable smoothing of geometry,
    * fonts, and images. Since the release of Processing 3.0,
-   * the noSmooth() function can only be run once for each
-   * sketch, either at the top of a sketch without a setup(),
-   * or after the size() function when used in a sketch with
-   * setup(). See the examples above for both scenarios.
+   * the <b>noSmooth()</b> function can only be run once for each
+   * sketch, either at the top of a sketch without a <b>setup()</b>,
+   * or after the <b>size()</b> function when used in a sketch with
+   * <b>setup()</b>. See the examples above for both scenarios.
    *
    * @webref environment
    * @webBrief Draws all geometry and fonts with jagged (aliased)
@@ -3391,22 +3391,22 @@ public class PApplet implements PConstants {
 
   /**
    *
-   * The delay() function causes the program to halt for a specified time.
+   * The <b>delay()</b> function causes the program to halt for a specified time.
    * Delay times are specified in thousandths of a second. For example,
-   * running delay(3000) will stop the program for three seconds and
-   * delay(500) will stop the program for a half-second.
+   * running <b>delay(3000)</b> will stop the program for three seconds and
+   * <b>delay(500)</b> will stop the program for a half-second.
    *
-   * The screen only updates when the end of draw() is reached, so delay()
-   * cannot be used to slow down drawing. For instance, you cannot use delay()
+   * The screen only updates when the end of <b>draw()</b> is reached, so <b>delay()</b>
+   * cannot be used to slow down drawing. For instance, you cannot use <b>delay()</b>
    * to control the timing of an animation.
    *
-   * The delay() function should only be used for pausing scripts (i.e.
+   * The <b>delay()</b> function should only be used for pausing scripts (i.e.
    * a script that needs to pause a few seconds before attempting a download,
    * or a sketch that needs to wait a few milliseconds before reading from
    * the serial port).
    *
    * @webref environment
-   * @webBrief The delay() function causes the program to halt for a specified time.
+   * @webBrief The <b>delay()</b> function causes the program to halt for a specified time.
    * @param napTime milliseconds to pause before running draw() again
    * @see PApplet#frameRate
    * @see PApplet#draw()
@@ -4368,7 +4368,7 @@ public class PApplet implements PConstants {
 
   /**
    *
-   * The printArray() function writes array data to the text
+   * The <b>printArray()</b> function writes array data to the text
    * area of the Processing environment's console. A new line
    * is put between each element of the array. This function
    * can only print one dimensional arrays.
@@ -4378,7 +4378,7 @@ public class PApplet implements PConstants {
    *
    *
  * @webref output:text_area
- * @webBrief The printArray() function writes array data to the text
+ * @webBrief Writes array data to the text
  * area of the Processing environment's console.
  * @param what one-dimensional array
  * @usage IDE
@@ -4521,7 +4521,7 @@ public class PApplet implements PConstants {
    *
    * Squares a number (multiplies a number by itself). The result is always a
    * positive number, as multiplying two negative numbers always yields a
-   * positive result. For example, -1 * -1 = 1.
+   * positive result. For example, <b>-1 * -1 = 1.</b>
    *
    * @webref math:calculation
    * @webBrief Squares a number (multiplies a number by itself).
@@ -5011,7 +5011,7 @@ public class PApplet implements PConstants {
    * direction in space commonly used in computer graphics and linear
    * algebra. Because it has no "start" position, the magnitude of a vector
    * can be thought of as the distance from coordinate (0,0) to its (x,y)
-   * value. Therefore, mag() is a shortcut for writing "dist(0, 0, x, y)".
+   * value. Therefore, <b>mag()</b> is a shortcut for writing <b>dist(0, 0, x, y)</b>.
    *
    * @webref math:calculation
    * @webBrief Calculates the magnitude (or length) of a vector.
@@ -10389,7 +10389,7 @@ public class PApplet implements PConstants {
    * where 0.0 is equal to the first point, 0.1 is very near the first point,
    * 0.5 is halfway in between, etc. <br />
    * An amount below 0 will be treated as 0. Likewise, amounts above 1 will be
-   * capped at 1. This is different from the behavior of lerp(), but necessary
+   * capped at 1. This is different from the behavior of <b>lerp()</b>, but necessary
    * because otherwise numbers outside the range will produce strange and
    * unexpected colors.
    *
@@ -12010,7 +12010,7 @@ public class PApplet implements PConstants {
    *
    * A quad is a quadrilateral, a four sided polygon. It is similar to a
    * rectangle, but the angles between its edges are not constrained to
-   * ninety degrees. The first pair of parameters (x1,y1) sets the first
+   * ninety degrees. The first pair of parameters <b>(x1,y1)</b> sets the first
    * vertex and the subsequent pairs should proceed clockwise or
    * counter-clockwise around the defined shape.
    *
@@ -14012,7 +14012,7 @@ public class PApplet implements PConstants {
    * the clipping volume where left and right are the minimum and maximum x
    * values, top and bottom are the minimum and maximum y values, and near and far
    * are the minimum and maximum z values. If no parameters are given, the default
-   * is used: ortho(-width/2, width/2, -height/2, height/2).
+   * is used: <b>ortho(-width/2, width/2, -height/2, height/2)</b>.
    *
    *
    * @webref lights_camera:camera
@@ -14060,8 +14060,8 @@ public class PApplet implements PConstants {
    * accurately than orthographic projection. The version of perspective
    * without parameters sets the default perspective and the version with
    * four parameters allows the programmer to set the area precisely. The
-   * default values are: perspective(PI/3.0, width/height, cameraZ/10.0,
-   * cameraZ*10.0) where cameraZ is ((height/2.0) / tan(PI*60.0/360.0));
+   * default values are: <b>perspective(PI/3.0, width/height, cameraZ/10.0,
+   * cameraZ*10.0)</b> where cameraZ is <b>((height/2.0) / tan(PI*60.0/360.0));</b>
    *
    *
    * @webref lights_camera:camera
@@ -14233,8 +14233,8 @@ public class PApplet implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -14262,8 +14262,8 @@ public class PApplet implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -14291,8 +14291,8 @@ public class PApplet implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -14321,10 +14321,10 @@ public class PApplet implements PConstants {
    * <br /><br />
    * The style information controlled by the following functions are included
    * in the style:
-   * fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(),
-   * imageMode(), rectMode(), ellipseMode(), shapeMode(), colorMode(),
-   * textAlign(), textFont(), textMode(), textSize(), textLeading(),
-   * emissive(), specular(), shininess(), ambient()
+   * <b>fill()<b>, <b>stroke()</b>, <b>tint()</b>, <b>strokeWeight()</b>, <b>strokeCap()</b>,<b>strokeJoin()</b>,
+   * <b>imageMode()</b>, <b>rectMode()</b>, <b>ellipseMode()</b>, <b>shapeMode()</b>, <b>colorMode()</b>,
+   * <b>textAlign()</b>, <b>textFont()</b>, <b>textMode()</b>, <b>textSize()</b>, <b>textLeading()</b>,
+   * <b>emissive()</b>, <b>specular()</b>, <b>shininess()</b>, <b>ambient()</b>
    *
    *
    * @webref structure
@@ -14369,7 +14369,7 @@ public class PApplet implements PConstants {
    * Sets the width of the stroke used for lines, points, and the border around
    * shapes. All widths are set in units of pixels. <br />
    * <br />
-   * Using point() with strokeWeight(1) or smaller may draw nothing to the screen,
+   * Using <b>point()<b> with <b>strokeWeight(1)<b> or smaller may draw nothing to the screen,
    * depending on the graphics settings of the computer. Workarounds include
    * setting the pixel using <b>set()</s> or drawing the point using either
    * <b>circle()</b> or <b>square()</b>.
@@ -14471,7 +14471,7 @@ public class PApplet implements PConstants {
    * <br />
    * When drawing in 2D with the default renderer, you may need
    * <b>hint(ENABLE_STROKE_PURE)</b> to improve drawing quality (at the expense of
-   * performance). See the hint() documentation for more details.
+   * performance). See the <b>hint()</b> documentation for more details.
    *
    * @webref color:setting
    * @webBrief Sets the color used to draw lines and borders around shapes.
@@ -14893,10 +14893,10 @@ public class PApplet implements PConstants {
   /**
    *
    * Sets the default ambient light, directional light, falloff, and specular
-   * values. The defaults are ambientLight(128, 128, 128) and
-   * directionalLight(128, 128, 128, 0, 0, -1), lightFalloff(1, 0, 0), and
-   * lightSpecular(0, 0, 0). Lights need to be included in the draw() to
-   * remain persistent in a looping program. Placing them in the setup() of a
+   * values. The defaults are <b>ambientLight(128, 128, 128)</b> and
+   * <b>directionalLight(128, 128, 128, 0, 0, -1)</b>, </b>lightFalloff(1, 0, 0)</b>, and
+   * <b>lightSpecular(0, 0, 0)</b>. Lights need to be included in the <b>draw()</b> to
+   * remain persistent in a looping program. Placing them in the <b>setup()</b> of a
    * looping program will cause them to only have an effect the first time
    * through the loop.
    *
@@ -15906,16 +15906,16 @@ public class PApplet implements PConstants {
    * of the following modes to blend the colors of source pixels (A) with the
    * ones of pixels in the destination image (B):<br />
    * <br />
-   * BLEND - linear interpolation of colours: C = A*factor + B<br />
+   * BLEND - linear interpolation of colours: <b>C = A*factor + B</b><br />
    * <br />
-   * ADD - additive blending with white clip: C = min(A*factor + B, 255)<br />
+   * ADD - additive blending with white clip: <b>C = min(A*factor + B, 255)</b><br />
    * <br />
-   * SUBTRACT - subtractive blending with black clip: C = max(B - A*factor,
-   * 0)<br />
+   * SUBTRACT - subtractive blending with black clip: <b>C = max(B - A*factor,
+   * 0)</b><br />
    * <br />
-   * DARKEST - only the darkest colour succeeds: C = min(A*factor, B)<br />
+   * DARKEST - only the darkest colour succeeds: <b>C = min(A*factor, B)</b><br />
    * <br />
-   * LIGHTEST - only the lightest colour succeeds: C = max(A*factor, B)<br />
+   * LIGHTEST - only the lightest colour succeeds: <b>C = max(A*factor, B)</b><br />
    * <br />
    * DIFFERENCE - subtract colors from underlying image.<br />
    * <br />

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -219,7 +219,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:pixels
-   * @webBrief Array containing the values for all the pixels in the display window.
+   * @webBrief Array containing the values for all the pixels in the display window
    * @see PApplet#loadPixels()
    * @see PApplet#updatePixels()
    * @see PApplet#get(int, int, int, int)
@@ -240,7 +240,7 @@ public class PApplet implements PConstants {
    * <b>size()</b> is not used in a program.
    *
    * @webref environment
-   * @webBrief System variable which stores the width of the display window.
+   * @webBrief System variable which stores the width of the display window
    * @see PApplet#height
    * @see PApplet#size(int, int)
    */
@@ -255,7 +255,7 @@ public class PApplet implements PConstants {
    * <b>size()</b> is not used in a program.
    *
    * @webref environment
-   * @webBrief System variable which stores the height of the display window.
+   * @webBrief System variable which stores the height of the display window
    * @see PApplet#width
    * @see PApplet#size(int, int)
    */
@@ -276,7 +276,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref environment
-   * @webBrief The actual pixel width when using high resolution display.
+   * @webBrief The actual pixel width when using high resolution display
    * @see PApplet#pixelHeight
    * @see #pixelDensity(int)
    * @see #displayDensity()
@@ -298,7 +298,7 @@ public class PApplet implements PConstants {
    * be <b>pixelWidth*pixelHeight</b>, not <b>width*height</b>.
    *
    * @webref environment
-   * @webBrief The actual pixel heigh when using high resolution display.
+   * @webBrief The actual pixel heigh when using high resolution display
    * @see PApplet#pixelWidth
    * @see #pixelDensity(int)
    * @see #displayDensity()
@@ -323,7 +323,7 @@ public class PApplet implements PConstants {
    * its most recent position.
    *
    * @webref input:mouse
-   * @webBrief The system variable that always contains the current horizontal coordinate of the mouse.
+   * @webBrief The system variable that always contains the current horizontal coordinate of the mouse
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
    * @see PApplet#pmouseY
@@ -353,7 +353,7 @@ public class PApplet implements PConstants {
    * its most recent position.
    *
    * @webref input:mouse
-   * @webBrief The system variable that always contains the current vertical coordinate of the mouse.
+   * @webBrief The system variable that always contains the current vertical coordinate of the mouse
    * @see PApplet#mouseX
    * @see PApplet#pmouseX
    * @see PApplet#pmouseY
@@ -392,7 +392,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief The system variable that always contains the horizontal
-   * position of the mouse in the frame previous to the current frame.
+   * position of the mouse in the frame previous to the current frame
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseY
@@ -416,7 +416,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief The system variable that always contains the vertical position
-   * of the mouse in the frame previous to the current frame.
+   * of the mouse in the frame previous to the current frame
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -477,7 +477,7 @@ public class PApplet implements PConstants {
    * If running on Mac OS, a ctrl-click will be interpreted as the right-hand
    * mouse button (unlike Java, which reports it as the left mouse).
    * @webref input:mouse
-   * @webBrief Shows which mouse button is pressed.
+   * @webBrief Shows which mouse button is pressed
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -504,7 +504,7 @@ public class PApplet implements PConstants {
    * listening for events.
    *
    * @webref input:mouse
-   * @webBrief Variable storing if a mouse button is pressed.
+   * @webBrief Variable storing if a mouse button is pressed
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -559,7 +559,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:keyboard
    * @webBrief The system variable that always contains the value of the most
-   * recent key on the keyboard that was used (either pressed or released).
+   * recent key on the keyboard that was used (either pressed or released)
    * @see PApplet#keyCode
    * @see PApplet#keyPressed
    * @see PApplet#keyPressed()
@@ -607,7 +607,7 @@ public class PApplet implements PConstants {
    * can be obtained from java.awt.event.KeyEvent, from the VK_XXXX variables.
    *
    * @webref input:keyboard
-   * @webBrief Used to detect special keys such as the UP, DOWN, LEFT, RIGHT arrow keys and ALT, CONTROL, SHIFT.
+   * @webBrief Used to detect special keys such as the UP, DOWN, LEFT, RIGHT arrow keys and ALT, CONTROL, SHIFT
    * @see PApplet#key
    * @see PApplet#keyPressed
    * @see PApplet#keyPressed()
@@ -625,7 +625,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:keyboard
    * @webBrief The boolean system variable that is <b>true</b> if any key
-   * is pressed and <b>false</b> if no keys are pressed.
+   * is pressed and <b>false</b> if no keys are pressed
    * @see PApplet#key
    * @see PApplet#keyCode
    * @see PApplet#keyPressed()
@@ -648,7 +648,7 @@ public class PApplet implements PConstants {
    * it is focused and <b>false</b> if not.
    *
    * @webref environment
-   * @webBrief Confirms if a Processing program is "focused".
+   * @webBrief Confirms if a Processing program is "focused"
    */
   public boolean focused = false;
 
@@ -679,7 +679,7 @@ public class PApplet implements PConstants {
    *
    * @webref environment
    * @webBrief The system variable that contains the approximate frame rate
-   * of the software as it executes.
+   * of the software as it executes
    * @see PApplet#frameRate(float)
    * @see PApplet#frameCount
    */
@@ -698,7 +698,7 @@ public class PApplet implements PConstants {
    *
    * @webref environment
    * @webBrief The system variable that contains the number of frames
-   * displayed since the program started.
+   * displayed since the program started
    * @see PApplet#frameRate(float)
    * @see PApplet#frameRate
    */
@@ -944,7 +944,7 @@ public class PApplet implements PConstants {
   *
   * @webref environment
   * @webBrief Used when absolutely necessary to define the parameters to <b>size()</b>
-  * with a variable.
+  * with a variable
   * @see PApplet#fullScreen()
   * @see PApplet#setup()
   * @see PApplet#size(int,int)
@@ -1019,7 +1019,7 @@ public class PApplet implements PConstants {
   *
   *
   * @webref environment
-  * @webBrief Returns "2" if the screen is high-density and "1" if not.
+  * @webBrief Returns "2" if the screen is high-density and "1" if not
   * @see PApplet#pixelDensity(int)
   * @see PApplet#size(int,int)
   */
@@ -1184,7 +1184,7 @@ public class PApplet implements PConstants {
    * example.
    *
    * @webref environment
-   * @webBrief Draws all geometry with smooth (anti-aliased) edges.
+   * @webBrief Draws all geometry with smooth (anti-aliased) edges
    * @param level either 2, 3, 4, or 8 depending on the renderer
    */
   public void smooth(int level) {
@@ -1211,7 +1211,7 @@ public class PApplet implements PConstants {
    * @webref environment
    * @webBrief Draws all geometry and fonts with jagged (aliased)
    * edges and images with hard edges between the pixels
-   * when enlarged rather than interpolating pixels.
+   * when enlarged rather than interpolating pixels
    */
   public void noSmooth() {
     if (insideSettings) {
@@ -1733,7 +1733,7 @@ public class PApplet implements PConstants {
    *
    *
  * @webref structure
- * @webBrief  The <b>setup()</b> function is called once when the program starts.
+ * @webBrief  The <b>setup()</b> function is called once when the program starts
  * @usage web_application
  * @see PApplet#size(int, int)
  * @see PApplet#loop()
@@ -1774,7 +1774,7 @@ public class PApplet implements PConstants {
  * @webref structure
  * @webBrief Called directly after <b>setup()</b> and continuously executes the lines
  * of code contained inside its block until the program is stopped or
- * <b>noLoop()</b> is called.
+ * <b>noLoop()</b> is called
  * @usage web_application
  * @see PApplet#setup()
  * @see PApplet#loop()
@@ -1847,7 +1847,7 @@ public class PApplet implements PConstants {
   * <b>size(displayWidth, displayHeight)</b>.
   *
   * @webref environment
-  * @webBrief Opens a sketch using the full size of the computer's display.
+  * @webBrief Opens a sketch using the full size of the computer's display
   * @param renderer the renderer to use, e.g. P2D, P3D, JAVA2D (default)
   * @see PApplet#settings()
   * @see PApplet#setup()
@@ -1955,7 +1955,7 @@ public class PApplet implements PConstants {
    * renderer and simply resize it.
    *
    * @webref environment
-   * @webBrief Defines the dimension of the display window in units of pixels.
+   * @webBrief Defines the dimension of the display window in units of pixels
    * @param width
    *          width of the display window in units of pixels
    * @param height
@@ -2172,7 +2172,7 @@ public class PApplet implements PConstants {
    *
    * @webref rendering
    * @webBrief Creates and returns a new <b>PGraphics</b> object of the types
-   *           P2D or P3D.
+   *           P2D or P3D
    * @param w
    *          width in pixels
    * @param h
@@ -2345,7 +2345,7 @@ public class PApplet implements PConstants {
    * without needing an absolute path.
    *
    * @webref image
-   * @webBrief Creates a new PImage (the datatype for storing images).
+   * @webBrief Creates a new <b>PImage</b> (the datatype for storing images)
    * @param w width in pixels
    * @param h height in pixels
    * @param format Either RGB, ARGB, ALPHA (grayscale alpha channel)
@@ -2521,7 +2521,7 @@ public class PApplet implements PConstants {
  * <b>noLoop()</b>.
  *
  * @webref structure
- * @webBrief Executes the code within <b>draw()</b> one time.
+ * @webBrief Executes the code within <b>draw()</b> one time
  * @usage web_application
  * @see PApplet#draw()
  * @see PApplet#loop()
@@ -2554,7 +2554,7 @@ public class PApplet implements PConstants {
  *
  * @webref structure
  * @webBrief Causes Processing to continuously execute the code within
- *           <b>draw()</b>.
+ *           <b>draw()</b>
  * @usage web_application
  * @see PApplet#noLoop()
  * @see PApplet#redraw()
@@ -2586,7 +2586,7 @@ public class PApplet implements PConstants {
    * Otherwise, the sketch would enter an odd state until <b>loop()</b> was called.
    *
  * @webref structure
- * @webBrief Stops Processing from continuously executing the code within <b>draw()</b>.
+ * @webBrief Stops Processing from continuously executing the code within <b>draw()</b>
  * @usage web_application
  * @see PApplet#loop()
  * @see PApplet#redraw()
@@ -2785,7 +2785,7 @@ public class PApplet implements PConstants {
    * completely inconsistent across platforms.
    *
    * @webref input:mouse
-   * @webBrief Called once after every time a mouse button is pressed.
+   * @webBrief Called once after every time a mouse button is pressed
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -2816,7 +2816,7 @@ public class PApplet implements PConstants {
    * for events.
    *
    * @webref input:mouse
-   * @webBrief Called every time a mouse button is released.
+   * @webBrief Called every time a mouse button is released
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -2852,7 +2852,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief Called once after a mouse button has been pressed and then
-   *           released.
+   *           released
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -2885,7 +2885,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief Called once every time the mouse moves and a mouse button is
-   *           pressed.
+   *           pressed
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -2919,7 +2919,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief Called every time the mouse moves and a mouse button is not
-   *           pressed.
+   *           pressed
    * @see PApplet#mouseX
    * @see PApplet#mouseY
    * @see PApplet#pmouseX
@@ -2977,7 +2977,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:mouse
    * @webBrief The code within the <b>mouseWheel()</b> event function
-   * is run when the mouse wheel is moved.
+   * is run when the mouse wheel is moved
    * @param event the MouseEvent
    * @see PApplet#mouseX
    * @see PApplet#mouseY
@@ -3142,7 +3142,7 @@ public class PApplet implements PConstants {
    * </PRE>
    *
    * @webref input:keyboard
-   * @webBrief Called once every time a key is pressed.
+   * @webBrief Called once every time a key is pressed
    * @see PApplet#key
    * @see PApplet#keyCode
    * @see PApplet#keyPressed
@@ -3167,7 +3167,7 @@ public class PApplet implements PConstants {
    * for events.
    *
    * @webref input:keyboard
-   * @webBrief called once every time a key is released.
+   * @webBrief Called once every time a key is released
    * @see PApplet#key
    * @see PApplet#keyCode
    * @see PApplet#keyPressed
@@ -3197,7 +3197,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:keyboard
    * @webBrief Called once every time a key is pressed, but action keys such as
-   *           Ctrl, Shift, and Alt are ignored.
+   *           Ctrl, Shift, and Alt are ignored
    * @see PApplet#keyPressed
    * @see PApplet#key
    * @see PApplet#keyCode
@@ -3248,7 +3248,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:time_date
    * @webBrief Returns the number of milliseconds (thousandths of a second) since
-   * starting an applet.
+   * starting an applet
    * @see PApplet#second()
    * @see PApplet#minute()
    * @see PApplet#hour()
@@ -3267,7 +3267,7 @@ public class PApplet implements PConstants {
    * <b>second()</b> function returns the current second as a value from 0 - 59.
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current second as a value from 0 - 59
    * @see PApplet#millis()
    * @see PApplet#minute()
    * @see PApplet#hour()
@@ -3286,7 +3286,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current minute as a value from 0 - 59
    * @see PApplet#millis()
    * @see PApplet#second()
    * @see PApplet#hour()
@@ -3305,7 +3305,7 @@ public class PApplet implements PConstants {
    * <b>hour()</b> function returns the current hour as a value from 0 - 23.
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current hour as a value from 0 - 23
    * @see PApplet#millis()
    * @see PApplet#second()
    * @see PApplet#minute()
@@ -3331,7 +3331,7 @@ public class PApplet implements PConstants {
    * or day of the year (1..365) then use java's Calendar.get()
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current day as a value from 1 - 31
    * @see PApplet#millis()
    * @see PApplet#second()
    * @see PApplet#minute()
@@ -3350,7 +3350,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current month as a value from 1 - 12
    * @see PApplet#millis()
    * @see PApplet#second()
    * @see PApplet#minute()
@@ -3371,7 +3371,8 @@ public class PApplet implements PConstants {
    *
    *
    * @webref input:time_date
-   * @webBrief Processing communicates with the clock on your computer.
+   * @webBrief Returns the current year as an integer (2003,
+   * 2004, 2005, etc)
    * @see PApplet#millis()
    * @see PApplet#second()
    * @see PApplet#minute()
@@ -3406,7 +3407,7 @@ public class PApplet implements PConstants {
    * the serial port).
    *
    * @webref environment
-   * @webBrief The <b>delay()</b> function causes the program to halt for a specified time.
+   * @webBrief The <b>delay()</b> function causes the program to halt for a specified time
    * @param napTime milliseconds to pause before running draw() again
    * @see PApplet#frameRate
    * @see PApplet#draw()
@@ -3431,7 +3432,7 @@ public class PApplet implements PConstants {
    * <b>setup()</b> is recommended. The default rate is 60 frames per second.
    *
    * @webref environment
-   * @webBrief Specifies the number of frames to be displayed every second.
+   * @webBrief Specifies the number of frames to be displayed every second
    * @param fps
    *          number of desired frames per second
    * @see PApplet#frameRate
@@ -3504,7 +3505,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Attempts to open an application or file using your platform's
-   *           launcher.
+   *           launcher
    * @param args
    *          arguments to the launcher, eg. a filename.
    * @usage Application
@@ -3788,7 +3789,7 @@ public class PApplet implements PConstants {
    * (particularly with P3D).
    *
    * @webref structure
-   * @webBrief Quits/stops/exits the program.
+   * @webBrief Quits/stops/exits the program
    */
   public void exit() {
     if (surface.isStopped()) {
@@ -3930,7 +3931,7 @@ public class PApplet implements PConstants {
    *
    * @webref structure
    * @webBrief Launch a new thread and call the specified function from that new
-   *           thread.
+   *           thread
    * @usage Application
    * @param name
    *          name of the function to be executed in a separate thread
@@ -3966,7 +3967,7 @@ public class PApplet implements PConstants {
    * images without a background, use <b>createGraphics()</b>.
    *
    * @webref output:image
-   * @webBrief Saves an image from the display window.
+   * @webBrief Saves an image from the display window
    * @param filename
    *          any sequence of letters and numbers
    * @see PApplet#saveFrame()
@@ -4016,7 +4017,7 @@ public class PApplet implements PConstants {
    *
    * @webref output:image
    * @webBrief Saves a numbered sequence of images, one image each time the
-   *           function is run.
+   *           function is run
    * @see PApplet#save(String)
    * @see PApplet#createGraphics(int, int, String, String)
    * @see PApplet#frameCount
@@ -4107,7 +4108,7 @@ public class PApplet implements PConstants {
    *
    * @webref environment
    * @webBrief Sets the cursor to a predefined symbol, an image, or makes it
-   *           visible if already hidden.
+   *           visible if already hidden
    * @see PApplet#noCursor()
    * @param img
    *          any variable of type PImage
@@ -4139,7 +4140,7 @@ public class PApplet implements PConstants {
    * Hide the cursor by creating a transparent image
    * and using it as a custom cursor.
    * @webref environment
-   * @webBrief Hides the cursor from view.
+   * @webBrief Hides the cursor from view
    * @see PApplet#cursor()
    * @usage Application
    */
@@ -4173,7 +4174,7 @@ public class PApplet implements PConstants {
  * can sometimes lock up the program, and cause the sketch to freeze.
  *
  * @webref output:text_area
- * @webBrief Writes to the console area of the Processing environment.
+ * @webBrief Writes to the console area of the Processing environment
  * @usage IDE
  * @param what
  *          data to print to console
@@ -4272,7 +4273,7 @@ public class PApplet implements PConstants {
    * loop can sometimes lock up the program, and cause the sketch to freeze.
    *
    * @webref output:text_area
-   * @webBrief Writes to the text area of the Processing environment's console.
+   * @webBrief Writes to the text area of the Processing environment's console
    * @usage IDE
    * @see PApplet#print(byte)
    * @see PApplet#printArray(Object)
@@ -4506,7 +4507,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref math:calculation
-   * @webBrief Calculates the absolute value (magnitude) of a number.
+   * @webBrief Calculates the absolute value (magnitude) of a number
    * @param n number to compute
    */
   static public final float abs(float n) {
@@ -4524,7 +4525,7 @@ public class PApplet implements PConstants {
    * positive result. For example, <b>-1 * -1 = 1.</b>
    *
    * @webref math:calculation
-   * @webBrief Squares a number (multiplies a number by itself).
+   * @webBrief Squares a number (multiplies a number by itself)
    * @param n number to square
    * @see PApplet#sqrt(float)
    */
@@ -4540,7 +4541,7 @@ public class PApplet implements PConstants {
    * is the opposite of squaring.
    *
    * @webref math:calculation
-   * @webBrief Calculates the square root of a number.
+   * @webBrief Calculates the square root of a number
    * @param n non-negative number
    * @see PApplet#pow(float, float)
    * @see PApplet#sq(float)
@@ -4556,7 +4557,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:calculation
    * @webBrief Calculates the natural logarithm (the base-<i>e</i> logarithm) of a
-   * number.
+   * number
    * @param n number greater than 0.0
    */
   static public final float log(float n) {
@@ -4570,7 +4571,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:calculation
    * @webBrief Returns Euler's number <i>e</i> (2.71828...) raised to the power of the
-   * <b>value</b> parameter.
+   * <b>value</b> parameter
    * @param n exponent to raise
    */
   static public final float exp(float n) {
@@ -4585,7 +4586,7 @@ public class PApplet implements PConstants {
    * expression 3*3*3*3*3 and <b>pow(3, -5)</b> is equivalent to 1 / 3*3*3*3*3.
    *
    * @webref math:calculation
-   * @webBrief Facilitates exponential expressions.
+   * @webBrief Facilitates exponential expressions
    * @param n base of the exponential expression
    * @param e power by which to raise the base
    * @see PApplet#sqrt(float)
@@ -4601,7 +4602,7 @@ public class PApplet implements PConstants {
  * values as parameters, or an array of any length.
  *
  * @webref math:calculation
- * @webBrief Determines the largest value in a sequence of numbers.
+ * @webBrief Determines the largest value in a sequence of numbers
  * @param a
  *          first number to compare
  * @param b
@@ -4707,7 +4708,7 @@ public class PApplet implements PConstants {
  * values as parameters, or an array of any length.
  *
  * @webref math:calculation
- * @webBrief Determines the smallest value in a sequence of numbers.
+ * @webBrief Determines the smallest value in a sequence of numbers
  * @param a
  *          first number
  * @param b
@@ -4782,7 +4783,7 @@ public class PApplet implements PConstants {
    * Constrains a value to not exceed a maximum and minimum value.
    *
    * @webref math:calculation
-   * @webBrief Constrains a value to not exceed a maximum and minimum value.
+   * @webBrief Constrains a value to not exceed a maximum and minimum value
    * @param amt the value to constrain
    * @param low minimum limit
    * @param high maximum limit
@@ -4801,7 +4802,7 @@ public class PApplet implements PConstants {
    * 6.28). Values are returned in the range -1 to 1.
    *
    * @webref math:trigonometry
-   * @webBrief Calculates the sine of an angle.
+   * @webBrief Calculates the sine of an angle
    * @param angle an angle in radians
    * @see PApplet#cos(float)
    * @see PApplet#tan(float)
@@ -4818,7 +4819,7 @@ public class PApplet implements PConstants {
    * PI*2). Values are returned in the range -1 to 1.
    *
    * @webref math:trigonometry
-   * @webBrief Calculates the cosine of an angle.
+   * @webBrief Calculates the cosine of an angle
    * @param angle an angle in radians
    * @see PApplet#sin(float)
    * @see PApplet#tan(float)
@@ -4836,7 +4837,7 @@ public class PApplet implements PConstants {
    * <b>infinity</b> to <b>-infinity</b>.
    *
    * @webref math:trigonometry
-   * @webBrief Calculates the ratio of the sine and cosine of an angle.
+   * @webBrief Calculates the ratio of the sine and cosine of an angle
    * @param angle an angle in radians
    * @see PApplet#cos(float)
    * @see PApplet#sin(float)
@@ -4853,7 +4854,7 @@ public class PApplet implements PConstants {
    * returned in the range <b>-PI/2</b> to <b>PI/2</b>.
    *
    * @webref math:trigonometry
-   * @webBrief The inverse of <b>sin()</b>, returns the arc sine of a value.
+   * @webBrief The inverse of <b>sin()</b>, returns the arc sine of a value
    * @param value the value whose arc sine is to be returned
    * @see PApplet#sin(float)
    * @see PApplet#acos(float)
@@ -4870,7 +4871,7 @@ public class PApplet implements PConstants {
    * returned in the range <b>0</b> to <b>PI (3.1415927)</b>.
    *
    * @webref math:trigonometry
-   * @webBrief The inverse of <b>cos()</b>, returns the arc cosine of a value.
+   * @webBrief The inverse of <b>cos()</b>, returns the arc cosine of a value
    * @param value the value whose arc cosine is to be returned
    * @see PApplet#cos(float)
    * @see PApplet#asin(float)
@@ -4887,7 +4888,7 @@ public class PApplet implements PConstants {
    * (exclusive) and values are returned in the range <b>-PI/2</b> to <b>PI/2 </b>.
    *
    * @webref math:trigonometry
-   * @webBrief The inverse of <b>tan()</b>, returns the arc tangent of a value.
+   * @webBrief The inverse of <b>tan()</b>, returns the arc tangent of a value
    * @param value -Infinity to Infinity (exclusive)
    * @see PApplet#tan(float)
    * @see PApplet#asin(float)
@@ -4909,7 +4910,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:trigonometry
    * @webBrief Calculates the angle (in radians) from a specified point to the
-   * coordinate origin as measured from the positive x-axis.
+   * coordinate origin as measured from the positive x-axis
    * @param y y-coordinate of the point
    * @param x x-coordinate of the point
    * @see PApplet#tan(float)
@@ -4927,7 +4928,7 @@ public class PApplet implements PConstants {
    * require their parameters to be specified in radians.
    *
    * @webref math:trigonometry
-   * @webBrief Converts a radian measurement to its corresponding value in degrees.
+   * @webBrief Converts a radian measurement to its corresponding value in degrees
    * @param radians radian value to convert to degrees
    * @see PApplet#radians(float)
    */
@@ -4944,7 +4945,7 @@ public class PApplet implements PConstants {
    * require their parameters to be specified in radians.
    *
    * @webref math:trigonometry
-   * @webBrief Converts a degree measurement to its corresponding value in radians.
+   * @webBrief Converts a degree measurement to its corresponding value in radians
    * @param degrees degree value to convert to radians
    * @see PApplet#degrees(float)
    */
@@ -4959,7 +4960,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:calculation
    * @webBrief Calculates the closest int value that is greater than or equal to the
-   * value of the parameter.
+   * value of the parameter
    * @param n number to round up
    * @see PApplet#floor(float)
    * @see PApplet#round(float)
@@ -4975,7 +4976,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:calculation
    * @webBrief Calculates the closest int value that is less than or equal to the value
-   * of the parameter.
+   * of the parameter
    * @param n number to round down
    * @see PApplet#ceil(float)
    * @see PApplet#round(float)
@@ -4990,7 +4991,7 @@ public class PApplet implements PConstants {
  * <b>round(133.8)</b> returns the value 134.
  *
  * @webref math:calculation
- * @webBrief Calculates the integer closest to the <b>value</b> parameter.
+ * @webBrief Calculates the integer closest to the <b>value</b> parameter
  * @param n
  *          number to round
  * @see PApplet#floor(float)
@@ -5014,7 +5015,7 @@ public class PApplet implements PConstants {
    * value. Therefore, <b>mag()</b> is a shortcut for writing <b>dist(0, 0, x, y)</b>.
    *
    * @webref math:calculation
-   * @webBrief Calculates the magnitude (or length) of a vector.
+   * @webBrief Calculates the magnitude (or length) of a vector
    * @param a first value
    * @param b second value
    * @param c third value
@@ -5034,7 +5035,7 @@ public class PApplet implements PConstants {
    * Calculates the distance between two points.
    *
    * @webref math:calculation
-   * @webBrief Calculates the distance between two points.
+   * @webBrief Calculates the distance between two points
    * @param x1 x-coordinate of the first point
    * @param y1 y-coordinate of the first point
    * @param z1 z-coordinate of the first point
@@ -5056,7 +5057,7 @@ public class PApplet implements PConstants {
    * creating motion along a straight path and for drawing dotted lines.
    *
    * @webref math:calculation
-   * @webBrief Calculates a number between two numbers at a specific increment.
+   * @webBrief Calculates a number between two numbers at a specific increment
    * @param start first value
    * @param stop second value
    * @param amt float between 0.0 and 1.0
@@ -5080,7 +5081,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:calculation
    * @webBrief Normalizes a number from another range into a value between 0 and
-   *           1.
+   *           1
    * @param value
    *          the incoming value to be converted
    * @param start
@@ -5107,7 +5108,7 @@ public class PApplet implements PConstants {
    * values are often intentional and useful.
    *
    * @webref math:calculation
-   * @webBrief Re-maps a number from one range to another.
+   * @webBrief Re-maps a number from one range to another
    * @param value
    *          the incoming value to be converted
    * @param start1
@@ -5198,7 +5199,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:random
    * @webBrief Returns a float from a random series of numbers having a mean of 0
-   * and standard deviation of 1.
+   * and standard deviation of 1
    * @see PApplet#random(float,float)
    * @see PApplet#noise(float, float, float)
    */
@@ -5225,7 +5226,7 @@ public class PApplet implements PConstants {
    * floating-point random number to an integer, use the <b>int()</b> function.
    *
    * @webref math:random
-   * @webBrief Generates random numbers.
+   * @webBrief Generates random numbers
    * @param low
    *          lower limit
    * @param high
@@ -5254,7 +5255,7 @@ public class PApplet implements PConstants {
   * the software is run.
   *
   * @webref math:random
-  * @webBrief Sets the seed value for <b>random()</b>.
+  * @webBrief Sets the seed value for <b>random()</b>
   * @param seed
   *          seed value
   * @see PApplet#random(float,float)
@@ -5354,7 +5355,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref math:random
-   * @webBrief Returns the Perlin noise value at specified coordinates.
+   * @webBrief Returns the Perlin noise value at specified coordinates
    * @param x
    *          x-coordinate in noise space
    * @param y
@@ -5465,7 +5466,7 @@ public class PApplet implements PConstants {
    *
    * @webref math:random
    * @webBrief Adjusts the character and level of detail produced by the Perlin
-   *           noise function.
+   *           noise function
    * @param lod
    *          number of octaves to be used by the noise
    * @see PApplet#noise(float, float, float)
@@ -5491,7 +5492,7 @@ public class PApplet implements PConstants {
    * numbers each time the software is run.
    *
    * @webref math:random
-   * @webBrief Sets the seed value for <b>noise()</b>.
+   * @webBrief Sets the seed value for <b>noise()</b>
    * @param seed seed value
    * @see PApplet#noise(float, float, float)
    * @see PApplet#noiseDetail(int, float)
@@ -5548,7 +5549,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:loading_displaying
-   * @webBrief Loads an image into a variable of type <b>PImage</b>.
+   * @webBrief Loads an image into a variable of type <b>PImage</b>
    * @param filename
    *          name of file to load, can be .gif, .jpg, .tga, or a handful of
    *          other image types depending on your platform
@@ -5604,7 +5605,7 @@ public class PApplet implements PConstants {
    *
    * @webref image:loading_displaying
    * @webBrief Loads images on a separate thread so that your sketch does not
-   *           freeze while images load during <b>setup()</b>.
+   *           freeze while images load during <b>setup()</b>
    * @param filename
    *          name of the file to load, can be .gif, .jpg, .tga, or a handful of
    *          other image types depending on your platform
@@ -5684,8 +5685,8 @@ public class PApplet implements PConstants {
    * not in UTF-8 format, see the <a href="http://processing.github.io/processing-javadocs/core/processing/data/XML.html">
    * developer's reference</a> for the XML object.
    * @webref input:files
-   * @webBrief Reads the contents of a file or URL and creates an XML
-   * object with its values.
+   * @webBrief Reads the contents of a file or URL and creates an <b>XML</b>
+   * object with its values
    * @param filename name of a file in the data folder or a URL.
    * @see XML
    * @see PApplet#parseXML(String)
@@ -5735,7 +5736,7 @@ public class PApplet implements PConstants {
    * simpler to use <b>loadXML()</b>.
    *
    * @webref input:files
-   * @webBrief Converts String content to an XML object
+   * @webBrief Converts String content to an <b>XML</b> object
    * @param xmlString
    *          the content to be parsed as XML
    * @return an XML object, or null
@@ -5770,7 +5771,7 @@ public class PApplet implements PConstants {
    * All files loaded and saved by the Processing API use UTF-8 encoding.
    *
    * @webref output:files
-   * @webBrief Writes the contents of an XML object to a file.
+   * @webBrief Writes the contents of an <b>XML</b> object to a file
    * @param xml
    *          the XML object to save to disk
    * @param filename
@@ -5807,7 +5808,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Takes a <b>String</b>, parses its contents, and returns a
-   *           <b>JSONObject</b>.
+   *           <b>JSONObject</b>
    * @param input
    *          String to parse as a JSONObject
    * @see PApplet#loadJSONObject(String)
@@ -5826,7 +5827,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Loads a JSON from the data folder or a URL, and returns a
-   *           <b>JSONObject</b>.
+   *           <b>JSONObject</b>
    * @param filename
    *          name of a file in the data folder or a URL
    * @see JSONObject
@@ -5879,7 +5880,7 @@ public class PApplet implements PConstants {
    * All files loaded and saved by the Processing API use UTF-8 encoding.
    *
    * @webref output:files
-   * @webBrief Writes the contents of a <b>JSONObject</b> object to a file.
+   * @webBrief Writes the contents of a <b>JSONObject</b> object to a file
    * @param json
    *          the JSONObject to save
    * @param filename
@@ -5918,7 +5919,7 @@ public class PApplet implements PConstants {
  * simpler to use <b>loadJSONArray()</b>.
  *
  * @webref input:files
- * @webBrief
+ * @webBrief Takes a <b>String</b>, parses its contents, and returns a <b>JSONArray</b>
  * @param input
  *          String to parse as a JSONArray
  * @see JSONObject
@@ -5940,7 +5941,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Takes a <b>String</b>, parses its contents, and returns a
-   *           <b>JSONArray</b>.
+   *           <b>JSONArray</b>
    * @param filename
    *          name of a file in the data folder or a URL
    * @see JSONArray
@@ -5989,7 +5990,7 @@ public class PApplet implements PConstants {
    * All files loaded and saved by the Processing API use UTF-8 encoding.
    *
    * @webref output:files
-   * @webBrief Writes the contents of a <b>JSONArray</b> object to a file.
+   * @webBrief Writes the contents of a <b>JSONArray</b> object to a file
    * @param json
    *          the JSONArray to save
    * @param filename
@@ -6048,8 +6049,8 @@ public class PApplet implements PConstants {
    * All files loaded and saved by the Processing API use UTF-8 encoding.
    *
    * @webref input:files
-   * @webBrief Reads the contents of a file or URL and creates an Table object
-   *           with its values.
+   * @webBrief Reads the contents of a file or URL and creates a <b>Table</b> object
+   *           with its values
    * @param filename
    *          name of a file in the data folder or a URL.
    * @see Table
@@ -6112,7 +6113,7 @@ public class PApplet implements PConstants {
    * All files loaded and saved by the Processing API use UTF-8 encoding.
    *
    * @webref output:files
-   * @webBrief Writes the contents of a Table object to a file.
+   * @webBrief Writes the contents of a <b>Table</b> object to a file
    * @param table
    *          the Table object to save to a file
    * @param filename
@@ -6195,7 +6196,7 @@ public class PApplet implements PConstants {
    * renderer, such as the PDF library.
    *
    * @webref typography:loading_displaying
-   * @webBrief Loads a font into a variable of type <b>PFont</b>.
+   * @webBrief Loads a font into a variable of type <b>PFont</b>
    * @param filename
    *          name of the font to load
    * @see PFont
@@ -6260,7 +6261,7 @@ public class PApplet implements PConstants {
    * and the requested font is not available on the machine running the sketch.
    *
    * @webref typography:loading_displaying
-   * @webBrief Dynamically converts a font to the format used by Processing.
+   * @webBrief Dynamically converts a font to the format used by Processing
    * @param name
    *          name of the font to load
    * @param size
@@ -6343,7 +6344,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Open a platform-specific file chooser dialog to select a file for
-   *           input.
+   *           input
    * @param prompt
    *          message to the user
    * @param callback
@@ -6389,7 +6390,7 @@ public class PApplet implements PConstants {
    * The callback is necessary because of how threading works.
    *
    * @webref output:files
-   * @webBrief Opens a platform-specific file chooser dialog to select a file for output.
+   * @webBrief Opens a platform-specific file chooser dialog to select a file for output
    * @param prompt message to the user
    * @param callback name of the method to be called when the selection is made
    */
@@ -6490,7 +6491,7 @@ public class PApplet implements PConstants {
    * threading works.
    *
    * @webref input:files
-   * @webBrief Opens a platform-specific file chooser dialog to select a folder.
+   * @webBrief Opens a platform-specific file chooser dialog to select a folder
    * @param prompt message to the user
    * @param callback name of the method to be called when the selection is made
    */
@@ -6767,7 +6768,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Creates a <b>BufferedReader</b> object that can be used to read
-   *           files line-by-line as individual <b>String</b> objects.
+   *           files line-by-line as individual <b>String</b> objects
    * @param filename
    *          name of the file to be opened
    * @see BufferedReader
@@ -6844,8 +6845,8 @@ public class PApplet implements PConstants {
    *
    *
    * @webref output:files
-   * @webBrief reates a new file in the sketch folder, and a <b>PrintWriter</b> object
-   * to write to it.
+   * @webBrief Creates a new file in the sketch folder, and a <b>PrintWriter</b> object
+   * to write to it
    * @param filename name of the file to be created
    * @see PrintWriter
    * @see PApplet#createReader
@@ -6960,7 +6961,7 @@ public class PApplet implements PConstants {
    * </UL>
    *
    * @webref input:files
-   * @webBrief This is a function for advanced programmers to open a Java InputStream.
+   * @webBrief This is a function for advanced programmers to open a Java <b>InputStream</b>
    * @param filename the name of the file to use as input
    * @see PApplet#createOutput(String)
    * @see PApplet#selectOutput(String,String)
@@ -7189,7 +7190,7 @@ public class PApplet implements PConstants {
    *
    * @webref input:files
    * @webBrief Reads the contents of a file or url and places it in a byte
-   *           array.
+   *           array
    * @param filename
    *          name of a file in the data folder or a URL.
    * @see PApplet#loadStrings(String)
@@ -7422,8 +7423,8 @@ public class PApplet implements PConstants {
    * Java methods for I/O.
    *
    * @webref input:files
-   * @webBrief Reads the contents of a file or url and creates a String array of
-   *           its individual lines.
+   * @webBrief Reads the contents of a file or url and creates a <b>String</b> array of
+   *           its individual lines
    * @param filename
    *          name of the file or url to load
    * @see PApplet#loadBytes(String)
@@ -7517,7 +7518,7 @@ public class PApplet implements PConstants {
    *
    * @webref output:files
    * @webBrief Similar to <b>createInput()</b>, this creates a Java
-   *           <b>OutputStream</b> for a given filename or path.
+   *           <b>OutputStream</b> for a given filename or path
    * @param filename
    *          name of the file to open
    * @see PApplet#createInput(String)
@@ -7559,7 +7560,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref output:files
-   * @webBrief Save the contents of a stream to a file in the sketch folder.
+   * @webBrief Save the contents of a stream to a file in the sketch folder
    * @param target
    *          name of the file to write to
    * @param source
@@ -7654,7 +7655,7 @@ public class PApplet implements PConstants {
    *
    * @webref output:files
    * @webBrief Opposite of <b>loadBytes()</b>, will write an entire array of
-   *           bytes to a file.
+   *           bytes to a file
    * @param filename
    *          name of the file to write to
    * @param data
@@ -7773,7 +7774,7 @@ public class PApplet implements PConstants {
    * platforms.
    *
    * @webref output:files
-   * @webBrief Writes an array of strings to a file, one line per string.
+   * @webBrief Writes an array of strings to a file, one line per string
    * @param filename
    *          filename for output
    * @param data
@@ -8080,7 +8081,7 @@ public class PApplet implements PConstants {
    *
    * @webref data:array_functions
    * @webBrief Sorts an array of numbers from smallest to largest and puts an
-   *           array of words in alphabetical order.
+   *           array of words in alphabetical order
    * @param list
    *          array to sort
    * @see PApplet#reverse(boolean[])
@@ -8177,7 +8178,7 @@ public class PApplet implements PConstants {
    * method, so most things that apply there are inherited.
    *
    * @webref data:array_functions
-   * @webBrief Copies an array (or part of an array) to another array.
+   * @webBrief Copies an array (or part of an array) to another array
    * @param src
    *          the source array
    * @param srcPosition
@@ -8252,7 +8253,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref data:array_functions
-   * @webBrief Increases the size of an array.
+   * @webBrief Increases the size of an array
    * @param list
    *          the array to expand
    * @see PApplet#shorten(boolean[])
@@ -8372,7 +8373,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref data:array_functions
-   * @webBrief Expands an array by one element and adds data to the new position.
+   * @webBrief Expands an array by one element and adds data to the new position
    * @param array array to append
    * @param value new data for the array
    * @see PApplet#shorten(boolean[])
@@ -8426,7 +8427,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref data:array_functions
-   * @webBrief Decreases an array by one element and returns the shortened array.
+   * @webBrief Decreases an array by one element and returns the shortened array
    * @param list array to shorten
    * @see PApplet#append(byte[], byte)
    * @see PApplet#expand(boolean[])
@@ -8476,7 +8477,7 @@ public class PApplet implements PConstants {
    * = (SomeClass[]) splice(array1, array2, index)</em>
    *
    * @webref data:array_functions
-   * @webBrief Inserts a value or array of values into an existing array.
+   * @webBrief Inserts a value or array of values into an existing array
    * @param list
    *          array to splice into
    * @param value
@@ -8650,7 +8651,7 @@ public class PApplet implements PConstants {
   * (SomeClass[]) subset(originalArray, 0, 4)</em>
   *
   * @webref data:array_functions
-  * @webBrief Extracts an array of elements from an existing array.
+  * @webBrief Extracts an array of elements from an existing array
   * @param list
   *          array to extract from
   * @param start
@@ -8775,7 +8776,7 @@ public class PApplet implements PConstants {
   * (SomeClass[]) concat(array1, array2)</em>.
   *
   * @webref data:array_functions
-  * @webBrief Concatenates two arrays.
+  * @webBrief Concatenates two arrays
   * @param a
   *          first array to concatenate
   * @param b
@@ -8843,7 +8844,7 @@ public class PApplet implements PConstants {
    * Reverses the order of an array.
    *
   * @webref data:array_functions
-  * @webBrief Reverses the order of an array.
+  * @webBrief Reverses the order of an array
   * @param list booleans[], bytes[], chars[], ints[], floats[], or Strings[]
   * @see PApplet#sort(String[], int)
   */
@@ -8926,7 +8927,7 @@ public class PApplet implements PConstants {
    * character and the zero width no-break space (U+FEFF) character.
    *
    * @webref data:string_functions
-   * @webBrief Removes whitespace characters from the beginning and end of a String.
+   * @webBrief Removes whitespace characters from the beginning and end of a <b>String</b>
    * @param str any string
    * @see PApplet#split(String, String)
    * @see PApplet#join(String[], char)
@@ -8965,8 +8966,8 @@ public class PApplet implements PConstants {
    * <b>nf()</b> or <b>nfs()</b>.
    *
    * @webref data:string_functions
-   * @webBrief Combines an array of Strings into one String, each separated by the
-   * character(s) used for the <b>separator</b> parameter.
+   * @webBrief Combines an array of <b>Strings</b> into one <b>String</b>, each separated by the
+   * character(s) used for the <b>separator</b> parameter
    * @param list array of Strings
    * @param separator char or String to be placed between each item
    * @see PApplet#split(String, String)
@@ -8996,8 +8997,8 @@ public class PApplet implements PConstants {
 
   /**
    *
-   * The <b>splitTokens()</b> function splits a String at one or many character
-   * delimiters or "tokens." The <b>delim</b> parameter specifies the character
+   * The <b>splitTokens()</b> function splits a <b>String</b> at one or many character
+   * delimiters or "tokens". The <b>delim</b> parameter specifies the character
    * or characters to be used as a boundary.<br />
    * <br />
    * If no <b>delim</b> characters are specified, any whitespace character is
@@ -9009,8 +9010,8 @@ public class PApplet implements PConstants {
    * conversion functions <b>int()</b> and <b>float()</b>.
    *
    * @webref data:string_functions
-   * @webBrief The splitTokens() function splits a String at one or many
-   *           character "tokens."
+   * @webBrief The <b>splitTokens()</b> function splits a <b>String</b> at one or many
+   *           character "tokens"
    * @param value
    *          the String to be split
    * @param delim
@@ -9058,8 +9059,8 @@ public class PApplet implements PConstants {
    * characters</a> on Wikipedia. -->
    *
    * @webref data:string_functions
-   * @webBrief The split() function breaks a string into pieces using a
-   *           character or string as the divider.
+   * @webBrief The <b>split()</b> function breaks a string into pieces using a
+   *           character or string as the divider
    * @usage web_application
    * @param value
    *          the String to be split
@@ -9171,9 +9172,9 @@ public class PApplet implements PConstants {
    * Tutorial</a> on the topic.
    *
    * @webref data:string_functions
-   * @webBrief The match() function is used to apply a regular expression to a
+   * @webBrief The function is used to apply a regular expression to a
    *           piece of text, and return matching groups (elements found inside
-   *           parentheses) as a <b>String</b> array. No match will return <b>null</b>.
+   *           parentheses) as a <b>String</b> array
    * @param str
    *          the String to be searched
    * @param regexp
@@ -9227,7 +9228,7 @@ public class PApplet implements PConstants {
    *
    * @webref data:string_functions
    * @webBrief This function is used to apply a regular expression to a piece of
-   *           text.
+   *           text
    * @param str
    *          the String to be searched
    * @param regexp
@@ -9787,7 +9788,7 @@ public class PApplet implements PConstants {
    * <b>int()</b>, <b>ceil()</b>, <b>floor()</b>, or <b>round()</b> functions.
    *
    * @webref data:string_functions
-   * @webBrief Utility function for formatting numbers into strings.
+   * @webBrief Utility function for formatting numbers into strings
    * @param nums
    *          the numbers to format
    * @param digits
@@ -9840,7 +9841,7 @@ public class PApplet implements PConstants {
    *
    * @webref data:string_functions
    * @webBrief Utility function for formatting numbers into strings and placing
-   *           appropriate commas to mark units of 1000.
+   *           appropriate commas to mark units of 1000
    * @param nums
    *          the numbers to format
    * @see PApplet#nf(float, int, int)
@@ -9892,7 +9893,7 @@ public class PApplet implements PConstants {
    * should always be positive integers.
    *
   * @webref data:string_functions
-  * @webBrief Utility function for formatting numbers into strings.
+  * @webBrief Utility function for formatting numbers into strings
   * @param num the number to format
   * @param digits number of digits to pad with zeroes
   * @see PApplet#nf(float, int, int)
@@ -9930,7 +9931,7 @@ public class PApplet implements PConstants {
   * <b>right</b> parameters should always be positive integers.
   *
   * @webref data:string_functions
-  * @webBrief Utility function for formatting numbers into strings.
+  * @webBrief Utility function for formatting numbers into strings
   * @param num
   *          the number to format
   * @param digits
@@ -10082,8 +10083,8 @@ public class PApplet implements PConstants {
    * increase the length of the <b>String</b> further.
    *
    * @webref data:conversion
-   * @webBrief Converts a byte, char, int, or color to a String containing the
-   *           equivalent hexadecimal notation.
+   * @webBrief Converts a <b>byte</b>, <b>char</b>, <b>int</b>, or <b>color</b> to a <b>String</b> containing the
+   *           equivalent hexadecimal notation
    * @param value
    *          the value to convert
    * @see PApplet#unhex(String)
@@ -10127,8 +10128,8 @@ public class PApplet implements PConstants {
   *
   *
   * @webref data:conversion
-  * @webBrief Converts a String representation of a hexadecimal number to its
-  *           equivalent integer value.
+  * @webBrief Converts a <b>String</b> representation of a hexadecimal number to its
+  *           equivalent integer value
   * @param value
   *          String to convert to an integer
   * @see PApplet#hex(int, int)
@@ -10186,8 +10187,8 @@ public class PApplet implements PConstants {
   * no effect.
   *
   * @webref data:conversion
-  * @webBrief Converts a byte, char, int, or color to a String containing the
-  *           equivalent binary notation.
+  * @webBrief Converts an <b>int</b>, <b>byte</b>, <b>char</b>, or <b>color</b> to a
+  * <b>String</b> containing the equivalent binary notation
   * @param value
   *          value to convert
   * @param digits
@@ -10221,8 +10222,8 @@ public class PApplet implements PConstants {
   * <b>8</b>.
   *
   * @webref data:conversion
-  * @webBrief Converts a String representation of a binary number to its
-  *           equivalent integer value.
+  * @webBrief Converts a <b>String</b> representation of a binary number to its
+  *           equivalent <b>integer</b> value
   * @param value
   *          String to convert to an integer
   * @see PApplet#binary(byte)
@@ -10265,7 +10266,7 @@ public class PApplet implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Creates colors for storing in variables of the <b>color</b>
-   *           datatype.
+   *           datatype
    * @param gray
    *          number specifying value between white and black
    * @see PApplet#colorMode(int)
@@ -10384,7 +10385,7 @@ public class PApplet implements PConstants {
 
   /**
    *
-   * Calculates a color between two colors at a specific increment. The
+   * Calculates a <b>color</b> between two colors at a specific increment. The
    * <b>amt</b> parameter is the amount to interpolate between the two values
    * where 0.0 is equal to the first point, 0.1 is very near the first point,
    * 0.5 is halfway in between, etc. <br />
@@ -10395,8 +10396,8 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:creating_reading
-   * @webBrief Calculates a color or colors between two color at a specific
-   *           increment.
+   * @webBrief Calculates a <b>color</b> or <b>colors</b> between two <b>colors</b> at a specific
+   *           increment
    * @usage web_application
    * @param c1
    *          interpolate from this color
@@ -10950,7 +10951,7 @@ public class PApplet implements PConstants {
    *
    * @webref output:files
    * @webBrief Opens a new file and all subsequent drawing functions are echoed
-   *           to this file as well as the display window.
+   *           to this file as well as the display window
    * @param renderer
    *          PDF or SVG
    * @param filename
@@ -10982,7 +10983,7 @@ public class PApplet implements PConstants {
    *
   * @webref output:files
   * @webBrief Stops the recording process started by <b>beginRecord()</b> and closes
-   * the file.
+   * the file
   * @see PApplet#beginRecord(String, String)
   */
   public void endRecord() {
@@ -11025,7 +11026,7 @@ public class PApplet implements PConstants {
    *
    * @webref output:files
    * @webBrief To create vectors from 3D data, use the <b>beginRaw()</b> and
-   * <b>endRaw()</b> commands.
+   * <b>endRaw()</b> commands
    * @param renderer for example, PDF or DXF
    * @param filename filename for output
    * @see PApplet#endRaw()
@@ -11062,7 +11063,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref output:files
-   * @webBrief Complement to <b>beginRaw()</b>; they must always be used together.
+   * @webBrief Complement to <b>beginRaw()</b>; they must always be used together
    * @see PApplet#beginRaw(String, String)
    */
   public void endRaw() {
@@ -11096,7 +11097,7 @@ public class PApplet implements PConstants {
    *
    * @webref image:pixels
    * @webBrief Loads the pixel data for the display window into the
-   *           <b>pixels[]</b> array.
+   *           <b>pixels[]</b> array
    * @see PApplet#pixels
    * @see PApplet#updatePixels()
    */
@@ -11114,7 +11115,7 @@ public class PApplet implements PConstants {
   *
   * @webref image:pixels
   * @webBrief Updates the display window with the data in the <b>pixels[]</b>
-  *           array.
+  *           array
   * @see PApplet#loadPixels()
   * @see PApplet#pixels
   */
@@ -11203,7 +11204,7 @@ public class PApplet implements PConstants {
    *
    * @webref shape:vertex
    * @webBrief Using the <b>beginShape()</b> and <b>endShape()</b> functions allow
-   *           creating more complex forms.
+   *           creating more complex forms
    * @param kind Either POINTS, LINES, TRIANGLES, TRIANGLE_FAN, TRIANGLE_STRIP,
    *             QUADS, or QUAD_STRIP
    * @see PShape
@@ -11239,7 +11240,7 @@ public class PApplet implements PConstants {
    * is identical to <b>glNormal3f()</b> in OpenGL.
    *
    * @webref lights_camera:lights
-   * @webBrief Sets the current normal vector.
+   * @webBrief Sets the current normal vector
    * @param nx x direction
    * @param ny y direction
    * @param nz z direction
@@ -11301,7 +11302,7 @@ public class PApplet implements PConstants {
    * (0,200). The same mapping in <b>NORMAL</b> is (0,0) (1,0) (1,1) (0,1).
    *
    * @webref image:textures
-   * @webBrief Sets the coordinate space for texture mapping.
+   * @webBrief Sets the coordinate space for texture mapping
    * @param mode either IMAGE or NORMAL
    * @see PGraphics#texture(PImage)
    * @see PGraphics#textureWrap(int)
@@ -11320,7 +11321,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:textures
-   * @webBrief Defines if textures repeat or draw once within a texture map.
+   * @webBrief Defines if textures repeat or draw once within a texture map
    * @param wrap Either CLAMP (default) or REPEAT
    * @see PGraphics#texture(PImage)
    * @see PGraphics#textureMode(int)
@@ -11343,7 +11344,7 @@ public class PApplet implements PConstants {
    * shape.
    *
    * @webref image:textures
-   * @webBrief Sets a texture to be applied to vertex points.
+   * @webBrief Sets a texture to be applied to vertex points
    * @param image reference to a PImage object
    * @see PGraphics#textureMode(int)
    * @see PGraphics#textureWrap(int)
@@ -11415,7 +11416,7 @@ public class PApplet implements PConstants {
  * changed with <b>textureMode()</b>.
  *
  * @webref shape:vertex
- * @webBrief All shapes are constructed by connecting a series of vertices.
+ * @webBrief All shapes are constructed by connecting a series of vertices
  * @param x x-coordinate of the vertex
  * @param y y-coordinate of the vertex
  * @param z z-coordinate of the vertex
@@ -11451,7 +11452,7 @@ public class PApplet implements PConstants {
    * or <b>rect()</b> within.
    *
    * @webref shape:vertex
-   * @webBrief Begins recording vertices for the shape.
+   * @webBrief Begins recording vertices for the shape
    */
   public void beginContour() {
     if (recorder != null) recorder.beginContour();
@@ -11475,7 +11476,7 @@ public class PApplet implements PConstants {
    * or <b>rect()</b> within.
    *
    * @webref shape:vertex
-   * @webBrief Stops recording vertices for the shape.
+   * @webBrief Stops recording vertices for the shape
    */
   public void endContour() {
     if (recorder != null) recorder.endContour();
@@ -11499,7 +11500,7 @@ public class PApplet implements PConstants {
    * beginning and the end).
    *
    * @webref shape:vertex
-   * @webBrief the companion to <b>beginShape()</b> and may only be called after <b>beginShape()</b>.
+   * @webBrief the companion to <b>beginShape()</b> and may only be called after <b>beginShape()</b>
    * @param mode use CLOSE to close the shape
    * @see PShape
    * @see PGraphics#beginShape(int)
@@ -11524,12 +11525,12 @@ public class PApplet implements PConstants {
    * <br />
    * If the file is not available or an error occurs, <b>null</b> will
    * be returned and an error message will be printed to the console.
-   * The error message does not halt the program, however the <b>null</b> value
+   * The error message does not halt the program, however the null value
    * may cause a NullPointerException if your code does not check whether
-   * the value returned is <b>null</b>.<br />
+   * the value returned is null.<br />
    *
    * @webref shape
-   * @webBrief Loads geometry into a variable of type <b>PShape</b>.
+   * @webBrief Loads geometry into a variable of type <b>PShape</b>
    * @param filename name of file to load, can be .svg or .obj
    * @see PShape
    * @see PApplet#createShape()
@@ -11576,7 +11577,7 @@ public class PApplet implements PConstants {
    * PShape class are in the <a href="http://processing.github.io/processing-javadocs/core/">Processing Javadoc</a>.
    *
    * @webref shape
-   * @webBrief The <b>createShape()</b> function is used to define a new shape.
+   * @webBrief The <b>createShape()</b> function is used to define a new shape
    * @see PShape
    * @see PShape#endShape()
    * @see PApplet#loadShape(String)
@@ -11601,7 +11602,7 @@ public class PApplet implements PConstants {
 
 
   /**
-   * Loads a shader into the PShader object. The shader file must be
+   * Loads a shader into the <b>PShader</b> object. The shader file must be
    * loaded in the sketch's "data" folder/directory to load correctly.
    * Shaders are compatible with the P2D and P3D renderers, but not
    * with the default renderer.<br />
@@ -11615,11 +11616,11 @@ public class PApplet implements PConstants {
    * be returned and an error message will be printed to the console.
    * The error message does not halt the program, however the null
    * value may cause a NullPointerException if your code does not check
-   * whether the value returned is <b>null</b>.<br />
+   * whether the value returned is null.<br />
    *
    *
    * @webref rendering:shaders
-   * @webBrief Loads a shader into the PShader object.
+   * @webBrief Loads a shader into the <b>PShader</b> object
    * @param fragFilename name of fragment shader file
    */
   public PShader loadShader(String fragFilename) {
@@ -11642,7 +11643,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref rendering:shaders
-   * @webBrief Applies the shader specified by the parameters.
+   * @webBrief Applies the shader specified by the parameters
    * @param shader name of shader file
    */
   public void shader(PShader shader) {
@@ -11667,7 +11668,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref rendering:shaders
-   * @webBrief Restores the default shaders.
+   * @webBrief Restores the default shaders
    */
   public void resetShader() {
     if (recorder != null) recorder.resetShader();
@@ -11702,7 +11703,7 @@ public class PApplet implements PConstants {
    *
    * @webref rendering
    * @webBrief Limits the rendering to the boundaries of a rectangle defined
-   * by the parameters.
+   * by the parameters
    * @param a x-coordinate of the rectangle, by default
    * @param b y-coordinate of the rectangle, by default
    * @param c width of the rectangle, by default
@@ -11720,7 +11721,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref rendering
-   * @webBrief Disables the clipping previously started by the <b>clip()</b> function.
+   * @webBrief Disables the clipping previously started by the <b>clip()</b> function
    */
   public void noClip() {
     if (recorder != null) recorder.noClip();
@@ -11737,15 +11738,15 @@ public class PApplet implements PConstants {
    * channel of (A) and (B) independently. The red channel is compared with
    * red, green with green, and blue with blue.<br />
    * <br />
-   * BLEND - linear interpolation of colors: C = A*factor + B. This is the default.<br />
+   * BLEND - linear interpolation of colors: <b>C = A*factor + B</b>. This is the default.<br />
    * <br />
-   * ADD - additive blending with white clip: C = min(A*factor + B, 255)<br />
+   * ADD - additive blending with white clip: <b>C = min(A*factor + B, 255)</b><br />
    * <br />
-   * SUBTRACT - subtractive blending with black clip: C = max(B - A*factor, 0)<br />
+   * SUBTRACT - subtractive blending with black clip: <b>C = max(B - A*factor, 0)</b><br />
    * <br />
-   * DARKEST - only the darkest color succeeds: C = min(A*factor, B)<br />
+   * DARKEST - only the darkest color succeeds: <b>C = min(A*factor, B)</b><br />
    * <br />
-   * LIGHTEST - only the lightest color succeeds: C = max(A*factor, B)<br />
+   * LIGHTEST - only the lightest color succeeds: <b>C = max(A*factor, B)</b><br />
    * <br />
    * DIFFERENCE - subtract colors from underlying image.<br />
    * <br />
@@ -11765,7 +11766,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref rendering
-   * @webBrief Blends the pixels in the display window according to a defined mode.
+   * @webBrief Blends the pixels in the display window according to a defined mode
    * @param mode the blending mode to use
    */
   public void blendMode(int mode) {
@@ -11796,7 +11797,7 @@ public class PApplet implements PConstants {
    * for more information).
    *
  * @webref shape:vertex
- * @webBrief Specifies vertex coordinates for Bezier curves.
+ * @webBrief Specifies vertex coordinates for Bezier curves
  * @param x2 the x-coordinate of the 1st control point
  * @param y2 the y-coordinate of the 1st control point
  * @param z2 the z-coordinate of the 1st control point
@@ -11832,7 +11833,7 @@ public class PApplet implements PConstants {
    * reference for more information).
    *
    * @webref shape:vertex
-   * @webBrief Specifies vertex coordinates for quadratic Bezier curves.
+   * @webBrief Specifies vertex coordinates for quadratic Bezier curves
    * @param cx the x-coordinate of the control point
    * @param cy the y-coordinate of the control point
    * @param x3 the x-coordinate of the anchor point
@@ -11876,7 +11877,7 @@ public class PApplet implements PConstants {
    *
   *
   * @webref shape:vertex
-  * @webBrief Specifies vertex coordinates for curves.
+  * @webBrief Specifies vertex coordinates for curves
   * @param x the x-coordinate of the vertex
   * @param y the y-coordinate of the vertex
   * @see PGraphics#curve(float, float, float, float, float, float, float, float, float, float, float, float)
@@ -11923,7 +11924,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a point, a coordinate in space at the dimension of one pixel.
+   * @webBrief Draws a point, a coordinate in space at the dimension of one pixel
    * @param x x-coordinate of the point
    * @param y y-coordinate of the point
    * @see PGraphics#stroke(int)
@@ -11956,7 +11957,7 @@ public class PApplet implements PConstants {
    * parameter in combination with <b>size()</b> as shown in the above example.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a line (a direct path between two points) to the screen.
+   * @webBrief Draws a line (a direct path between two points) to the screen
    * @param x1 x-coordinate of the first point
    * @param y1 y-coordinate of the first point
    * @param x2 x-coordinate of the second point
@@ -11990,7 +11991,7 @@ public class PApplet implements PConstants {
    * second point, and the last two arguments specify the third point.
    *
    * @webref shape:2d_primitives
-   * @webBrief A triangle is a plane created by connecting three points.
+   * @webBrief A triangle is a plane created by connecting three points
    * @param x1 x-coordinate of the first point
    * @param y1 y-coordinate of the first point
    * @param x2 x-coordinate of the second point
@@ -12010,12 +12011,12 @@ public class PApplet implements PConstants {
    *
    * A quad is a quadrilateral, a four sided polygon. It is similar to a
    * rectangle, but the angles between its edges are not constrained to
-   * ninety degrees. The first pair of parameters <b>(x1,y1)</b> sets the first
+   * ninety degrees. The first pair of parameters (x1,y1) sets the first
    * vertex and the subsequent pairs should proceed clockwise or
    * counter-clockwise around the defined shape.
    *
    * @webref shape:2d_primitives
-   * @webBrief A quad is a quadrilateral, a four sided polygon.
+   * @webBrief A quad is a quadrilateral, a four sided polygon
    * @param x1 x-coordinate of the first corner
    * @param y1 y-coordinate of the first corner
    * @param x2 x-coordinate of the second corner
@@ -12057,7 +12058,7 @@ public class PApplet implements PConstants {
    * case-sensitive language.
    *
    * @webref shape:attributes
-   * @webBrief Modifies the location from which rectangles draw.
+   * @webBrief Modifies the location from which rectangles draw
    * @param mode either CORNER, CORNERS, CENTER, or RADIUS
    * @see PGraphics#rect(float, float, float, float)
    */
@@ -12085,7 +12086,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a rectangle to the screen.
+   * @webBrief Draws a rectangle to the screen
    * @param a x-coordinate of the rectangle by default
    * @param b y-coordinate of the rectangle by default
    * @param c width of the rectangle by default
@@ -12132,7 +12133,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a square to the screen.
+   * @webBrief Draws a square to the screen
    * @param x x-coordinate of the rectangle by default
    * @param y y-coordinate of the rectangle by default
    * @param extent width and height of the rectangle by default
@@ -12172,7 +12173,7 @@ public class PApplet implements PConstants {
    *
    * @webref shape:attributes
    * @webBrief The origin of the ellipse is modified by the <b>ellipseMode()</b>
-   *           function.
+   *           function
    * @param mode either CENTER, RADIUS, CORNER, or CORNERS
    * @see PApplet#ellipse(float, float, float, float)
    * @see PApplet#arc(float, float, float, float, float, float)
@@ -12191,7 +12192,7 @@ public class PApplet implements PConstants {
    * be changed with the <b>ellipseMode()</b> function.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws an ellipse (oval) in the display window.
+   * @webBrief Draws an ellipse (oval) in the display window
    * @param a x-coordinate of the ellipse
    * @param b y-coordinate of the ellipse
    * @param c width of the ellipse by default
@@ -12225,7 +12226,7 @@ public class PApplet implements PConstants {
    * arc yourself with <b>beginShape()</b>/<b>endShape()</b> or a <b>PShape</b>.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws an arc in the display window.
+   * @webBrief Draws an arc in the display window
    * @param a     x-coordinate of the arc's ellipse
    * @param b     y-coordinate of the arc's ellipse
    * @param c     width of the arc's ellipse by default
@@ -12262,7 +12263,7 @@ public class PApplet implements PConstants {
    * function.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a circle to the screen.
+   * @webBrief Draws a circle to the screen
    * @param x x-coordinate of the ellipse
    * @param y y-coordinate of the ellipse
    * @param extent width and height of the ellipse by default
@@ -12277,12 +12278,12 @@ public class PApplet implements PConstants {
 
   /**
    *
-   * A box is an extruded rectangle. A box with equal dimension on all sides
+   * A box is an extruded <b>rectangle</b>. A box with equal dimension on all sides
    * is a cube.
    *
    *
    * @webref shape:3d_primitives
-   * @webBrief A box is an extruded rectangle.
+   * @webBrief A box is an extruded <b>rectangle</b>
    * @param size dimension of the box in all dimensions (creates a cube)
    * @see PGraphics#sphere(float)
    */
@@ -12326,7 +12327,7 @@ public class PApplet implements PConstants {
    * @param res number of segments (minimum 3) used per full circle revolution
    * @webref shape:3d_primitives
    * @webBrief Controls the detail used to render a sphere by adjusting the number of
-   * vertices of the sphere mesh.
+   * vertices of the sphere mesh
    * @see PGraphics#sphere(float)
    */
   public void sphereDetail(int res) {
@@ -12372,7 +12373,7 @@ public class PApplet implements PConstants {
    * </PRE>
    *
    * @webref shape:3d_primitives
-   * @webBrief A sphere is a hollow ball made from tessellated triangles.
+   * @webBrief A sphere is a hollow ball made from tessellated triangles
    * @param r the radius of the sphere
    * @see PGraphics#sphereDetail(int)
    */
@@ -12413,7 +12414,7 @@ public class PApplet implements PConstants {
    * endShape();</PRE>
    *
    * @webref shape:curves
-   * @webBrief Evaluates the Bezier at point t for points a, b, c, d.
+   * @webBrief Evaluates the Bezier at point t for points a, b, c, d
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -12439,7 +12440,7 @@ public class PApplet implements PConstants {
    * Code submitted by Dave Bollinger (davbol) for release 0136.
    *
    * @webref shape:curves
-   * @webBrief Calculates the tangent of a point on a Bezier curve.
+   * @webBrief Calculates the tangent of a point on a Bezier curve
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -12462,7 +12463,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Sets the resolution at which Beziers display.
+   * @webBrief Sets the resolution at which Beziers display
    * @param detail resolution of the curves
    * @see PGraphics#curve(float, float, float, float, float, float, float, float,
    *      float, float, float, float)
@@ -12519,7 +12520,7 @@ public class PApplet implements PConstants {
    * <PRE>bezier(x1, y1, cx, cy, cx, cy, x2, y2);</PRE>
    *
    * @webref shape:curves
-   * @webBrief Draws a Bezier curve on the screen.
+   * @webBrief Draws a Bezier curve on the screen
    * @param x1 coordinates for the first anchor point
    * @param y1 coordinates for the first anchor point
    * @param z1 coordinates for the first anchor point
@@ -12557,7 +12558,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Evaluates the curve at point t for points a, b, c, d.
+   * @webBrief Evaluates the curve at point t for points a, b, c, d
    * @param a coordinate of first control point
    * @param b coordinate of first point on the curve
    * @param c coordinate of second point on the curve
@@ -12584,7 +12585,7 @@ public class PApplet implements PConstants {
    * Code thanks to Dave Bollinger (Bug #715)
    *
    * @webref shape:curves
-   * @webBrief Calculates the tangent of a point on a curve.
+   * @webBrief Calculates the tangent of a point on a curve
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -12608,7 +12609,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Sets the resolution at which curves display.
+   * @webBrief Sets the resolution at which curves display
    * @param detail resolution of the curves
    * @see PGraphics#curve(float, float, float, float, float, float, float, float, float, float, float, float)
    * @see PGraphics#curveVertex(float, float)
@@ -12633,7 +12634,7 @@ public class PApplet implements PConstants {
    *
    * @webref shape:curves
    * @webBrief Modifies the quality of forms created with <b>curve()</b> and
-   *           <b>curveVertex()</b>.
+   *           <b>curveVertex()</b>
    * @param tightness amount of deformation from the original vertices
    * @see PGraphics#curve(float, float, float, float, float, float, float, float,
    *      float, float, float, float)
@@ -12673,7 +12674,7 @@ public class PApplet implements PConstants {
    * </PRE>
    *
    * @webref shape:curves
-   * @webBrief Draws a curved line on the screen.
+   * @webBrief Draws a curved line on the screen
    * @param x1 coordinates for the beginning control point
    * @param y1 coordinates for the beginning control point
    * @param x2 coordinates for the first point
@@ -12733,7 +12734,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:loading_displaying
-   * @webBrief Modifies the location from which images draw.
+   * @webBrief Modifies the location from which images draw
    * @param mode either CORNER, CORNERS, or CENTER
    * @see PApplet#loadImage(String, String)
    * @see PImage
@@ -12767,7 +12768,7 @@ public class PApplet implements PConstants {
    * renderer, smooth() will also improve image quality of resized images.
    *
    * @webref image:loading_displaying
-   * @webBrief Displays images to the screen.
+   * @webBrief Displays images to the screen
    * @param img the image to display
    * @param a   x-coordinate of the image by default
    * @param b   y-coordinate of the image by default
@@ -12825,7 +12826,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:loading_displaying
-   * @webBrief Modifies the location from which shapes draw.
+   * @webBrief Modifies the location from which shapes draw
    * @param mode either CORNER, CORNERS, CENTER
    * @see PShape
    * @see PGraphics#shape(PShape)
@@ -12856,7 +12857,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:loading_displaying
-   * @webBrief Displays shapes to the screen.
+   * @webBrief Displays shapes to the screen
    * @param shape the shape to display
    * @param x     x-coordinate of the shape
    * @param y     y-coordinate of the shape
@@ -12919,7 +12920,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the current alignment for drawing text.
+   * @webBrief Sets the current alignment for drawing text
    * @param alignX horizontal alignment, either LEFT, CENTER, or RIGHT
    * @param alignY vertical alignment, either TOP, BOTTOM, CENTER, or BASELINE
    * @see PApplet#loadFont(String)
@@ -12942,7 +12943,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:metrics
-   * @webBrief Returns ascent of the current font at its current size.
+   * @webBrief Returns ascent of the current font at its current size
    * @see PGraphics#textDescent()
    */
   public float textAscent() {
@@ -12956,7 +12957,7 @@ public class PApplet implements PConstants {
    * useful for determining the height of the font below the baseline.
    *
    * @webref typography:metrics
-   * @webBrief Returns descent of the current font at its current size.
+   * @webBrief Returns descent of the current font at its current size
    * @see PGraphics#textAscent()
    */
   public float textDescent() {
@@ -12985,7 +12986,7 @@ public class PApplet implements PConstants {
    *
    * @webref typography:loading_displaying
    * @webBrief Sets the current font that will be drawn with the <b>text()</b>
-   *           function.
+   *           function
    * @param which any variable of the type PFont
    * @see PApplet#createFont(String, float, boolean)
    * @see PApplet#loadFont(String)
@@ -13019,7 +13020,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the spacing between lines of text in units of pixels.
+   * @webBrief Sets the spacing between lines of text in units of pixels
    * @param leading the size in pixels for spacing between lines
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -13052,7 +13053,7 @@ public class PApplet implements PConstants {
    * <b>beginRaw()</b>.
    *
    * @webref typography:attributes
-   * @webBrief Sets the way text draws to the screen.
+   * @webBrief Sets the way text draws to the screen
    * @param mode either MODEL or SHAPE
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -13074,7 +13075,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the current font size.
+   * @webBrief Sets the current font size
    * @param size the size of the letters in units of pixels
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -13101,7 +13102,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Calculates and returns the width of any character or text string.
+   * @webBrief Calculates and returns the width of any character or text string
    * @param str the String of characters to measure
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -13145,7 +13146,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref typography:loading_displaying
-   * @webBrief Draws text to the screen.
+   * @webBrief Draws text to the screen
    * @param c the alphanumeric character to be displayed
    * @param x x-coordinate of text
    * @param y y-coordinate of text
@@ -13308,7 +13309,7 @@ public class PApplet implements PConstants {
    * @webref structure
    * @webBrief The <b>push()</b> function saves the current drawing style
    * settings and transformations, while <b>pop()</b> restores these
-   * settings.
+   * settings
    * @see PGraphics#pop()
    */
   public void push() {
@@ -13346,7 +13347,7 @@ public class PApplet implements PConstants {
    *
    * @webref structure
    * @webBrief The <b>pop()</b> function restores the previous drawing style
-   * settings and transformations after <b>push()</b> has changed them.
+   * settings and transformations after <b>push()</b> has changed them
    * @see PGraphics#push()
    */
   public void pop() {
@@ -13368,7 +13369,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Pushes the current transformation matrix onto the matrix stack.
+   * @webBrief Pushes the current transformation matrix onto the matrix stack
    * @see PGraphics#popMatrix()
    * @see PGraphics#translate(float, float, float)
    * @see PGraphics#scale(float)
@@ -13395,7 +13396,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Pops the current transformation matrix off the matrix stack.
+   * @webBrief Pops the current transformation matrix off the matrix stack
    * @see PGraphics#pushMatrix()
    */
   public void popMatrix() {
@@ -13423,7 +13424,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Specifies an amount to displace objects within the display window.
+   * @webBrief Specifies an amount to displace objects within the display window
    * @param x left/right translation
    * @param y up/down translation
    * @see PGraphics#popMatrix()
@@ -13469,7 +13470,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Rotates a shape the amount specified by the <b>angle</b> parameter.
+   * @webBrief Rotates a shape the amount specified by the <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13503,7 +13504,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the x-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13537,7 +13538,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the y-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13571,7 +13572,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the z-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13618,7 +13619,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Increases or decreases the size of a shape by expanding and
-   *           contracting vertices.
+   *           contracting vertices
    * @param s percentage to scale the object
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
@@ -13679,7 +13680,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Shears a shape around the x-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of shear specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13714,7 +13715,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Shears a shape around the y-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of shear specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -13736,7 +13737,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Replaces the current matrix with the identity matrix.
+   * @webBrief Replaces the current matrix with the identity matrix
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
    * @see PGraphics#applyMatrix(PMatrix)
@@ -13753,12 +13754,12 @@ public class PApplet implements PConstants {
    * Multiplies the current matrix by the one specified through the
    * parameters. This is very slow because it will try to calculate the
    * inverse of the transform, so avoid it whenever possible. The equivalent
-   * function in OpenGL is glMultMatrix().
+   * function in OpenGL is <b>glMultMatrix()</b>.
    *
    *
    * @webref transform
    * @webBrief Multiplies the current matrix by the one specified through the
-   * parameters.
+   * parameters
    * @source
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
@@ -13877,7 +13878,7 @@ public class PApplet implements PConstants {
    *
    * @webref transform
    * @webBrief Prints the current matrix to the Console (the text window at the bottom
-   * of Processing).
+   * of Processing)
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
    * @see PGraphics#resetMatrix()
@@ -13911,7 +13912,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief The <b>beginCamera()</b> and <b>endCamera()</b> functions enable
-   * advanced customization of the camera space.
+   * advanced customization of the camera space
    * @see PGraphics#camera()
    * @see PGraphics#endCamera()
    * @see PGraphics#applyMatrix(PMatrix)
@@ -13934,7 +13935,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief The <b>beginCamera()</b> and <b>endCamera()</b> functions enable
-   * advanced customization of the camera space.
+   * advanced customization of the camera space
    * @see PGraphics#beginCamera()
    * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
    */
@@ -13958,7 +13959,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Sets the position of the camera.
+   * @webBrief Sets the position of the camera
    * @see PGraphics#beginCamera()
    * @see PGraphics#endCamera()
    * @see PGraphics#frustum(float, float, float, float, float, float)
@@ -13995,7 +13996,7 @@ public class PApplet implements PConstants {
    *
  * @webref lights_camera:camera
  * @webBrief Prints the current camera matrix to the Console (the text window at the
- * bottom of Processing).
+ * bottom of Processing)
  * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
  */
   public void printCamera() {
@@ -14017,7 +14018,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief Sets an orthographic projection and defines a parallel clipping
-   *           volume.
+   *           volume
    */
   public void ortho() {
     if (recorder != null) recorder.ortho();
@@ -14061,12 +14062,12 @@ public class PApplet implements PConstants {
    * without parameters sets the default perspective and the version with
    * four parameters allows the programmer to set the area precisely. The
    * default values are: <b>perspective(PI/3.0, width/height, cameraZ/10.0,
-   * cameraZ*10.0)</b> where cameraZ is <b>((height/2.0) / tan(PI*60.0/360.0));</b>
+   * cameraZ*10.0)</b> where cameraZ is <b>((height/2.0) / tan(PI*60.0/360.0))</b>
    *
    *
    * @webref lights_camera:camera
    * @webBrief Sets a perspective projection applying foreshortening, making distant
-   * objects appear smaller than closer ones.
+   * objects appear smaller than closer ones
    */
   public void perspective() {
     if (recorder != null) recorder.perspective();
@@ -14110,7 +14111,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Sets a perspective matrix defined through the parameters.
+   * @webBrief Sets a perspective matrix defined through the parameters
    * @param left   left coordinate of the clipping plane
    * @param right  right coordinate of the clipping plane
    * @param bottom bottom coordinate of the clipping plane
@@ -14139,7 +14140,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Prints the current projection matrix to the Console.
+   * @webBrief Prints the current projection matrix to the Console
    * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
    */
   public void printProjection() {
@@ -14156,7 +14157,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the X value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @see PGraphics#screenY(float, float, float)
@@ -14175,7 +14176,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the Y value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @see PGraphics#screenX(float, float, float)
@@ -14210,7 +14211,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the Z value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -14239,7 +14240,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -14268,7 +14269,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -14297,7 +14298,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -14328,7 +14329,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref structure
-   * @webBrief Saves the current style settings and <b>popStyle()</b> restores the prior settings.
+   * @webBrief Saves the current style settings and <b>popStyle()</b> restores the prior settings
    * @see PGraphics#popStyle()
    */
   public void pushStyle() {
@@ -14369,7 +14370,7 @@ public class PApplet implements PConstants {
    * Sets the width of the stroke used for lines, points, and the border around
    * shapes. All widths are set in units of pixels. <br />
    * <br />
-   * Using <b>point()<b> with <b>strokeWeight(1)<b> or smaller may draw nothing to the screen,
+   * Using point() with strokeWeight(1) or smaller may draw nothing to the screen,
    * depending on the graphics settings of the computer. Workarounds include
    * setting the pixel using <b>set()</s> or drawing the point using either
    * <b>circle()</b> or <b>square()</b>.
@@ -14377,7 +14378,7 @@ public class PApplet implements PConstants {
    *
    * @webref shape:attributes
    * @webBrief Sets the width of the stroke used for lines, points, and the border
-   *           around shapes.
+   *           around shapes
    * @param weight the weight (in pixels) of the stroke
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeJoin(int)
@@ -14397,7 +14398,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref shape:attributes
-   * @webBrief Sets the style of the joints which connect line segments.
+   * @webBrief Sets the style of the joints which connect line segments
    * @param join either MITER, BEVEL, ROUND
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeWeight(float)
@@ -14419,7 +14420,7 @@ public class PApplet implements PConstants {
    * <b>strokeCap(SQUARE)</b> (no cap) causes points to become invisible.
    *
    * @webref shape:attributes
-   * @webBrief Sets the style for rendering line endings.
+   * @webBrief Sets the style for rendering line endings
    * @param cap either SQUARE, PROJECT, or ROUND
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeWeight(float)
@@ -14439,7 +14440,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Disables drawing the stroke (outline).
+   * @webBrief Disables drawing the stroke (outline)
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#fill(float, float, float, float)
    * @see PGraphics#noFill()
@@ -14471,10 +14472,10 @@ public class PApplet implements PConstants {
    * <br />
    * When drawing in 2D with the default renderer, you may need
    * <b>hint(ENABLE_STROKE_PURE)</b> to improve drawing quality (at the expense of
-   * performance). See the <b>hint()</b> documentation for more details.
+   * performance). See the hint() documentation for more details.
    *
    * @webref color:setting
-   * @webBrief Sets the color used to draw lines and borders around shapes.
+   * @webBrief Sets the color used to draw lines and borders around shapes
    * @param rgb color value in hexadecimal notation
    * @see PGraphics#noStroke()
    * @see PGraphics#strokeWeight(float)
@@ -14541,7 +14542,7 @@ public class PApplet implements PConstants {
    *
    * @webref image:loading_displaying
    * @webBrief Removes the current fill value for displaying images and reverts to
-   * displaying images with their original hues.
+   * displaying images with their original hues
    * @usage web_application
    * @see PGraphics#tint(float, float, float, float)
    * @see PGraphics#image(PImage, float, float, float, float)
@@ -14579,7 +14580,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:loading_displaying
-   * @webBrief Sets the fill value for displaying images.
+   * @webBrief Sets the fill value for displaying images
    * @usage web_application
    * @param rgb color value in hexadecimal notation
    * @see PGraphics#noTint()
@@ -14639,7 +14640,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Disables filling geometry.
+   * @webBrief Disables filling geometry
    * @usage web_application
    * @see PGraphics#fill(float, float, float, float)
    * @see PGraphics#stroke(int, float)
@@ -14675,7 +14676,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Sets the color used to fill shapes.
+   * @webBrief Sets the color used to fill shapes
    * @usage web_application
    * @param rgb color variable or hex value
    * @see PGraphics#noFill()
@@ -14744,7 +14745,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:material_properties
-   * @webBrief Sets the ambient reflectance for shapes drawn to the screen.
+   * @webBrief Sets the ambient reflectance for shapes drawn to the screen
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#emissive(float, float, float)
@@ -14788,7 +14789,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:material_properties
    * @webBrief Sets the specular color of the materials used for shapes drawn to the
-   * screen, which sets the color of highlights.
+   * screen, which sets the color of highlights
    * @usage web_application
    * @param rgb color to set
    * @see PGraphics#lightSpecular(float, float, float)
@@ -14832,7 +14833,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:material_properties
-   * @webBrief Sets the amount of gloss in the surface of shapes.
+   * @webBrief Sets the amount of gloss in the surface of shapes
    * @usage web_application
    * @param shine degree of shininess
    * @see PGraphics#emissive(float, float, float)
@@ -14855,7 +14856,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:material_properties
    * @webBrief Sets the emissive color of the material used for drawing shapes drawn to
-   * the screen.
+   * the screen
    * @usage web_application
    * @param rgb color to set
    * @see PGraphics#ambient(float, float, float)
@@ -14894,7 +14895,7 @@ public class PApplet implements PConstants {
    *
    * Sets the default ambient light, directional light, falloff, and specular
    * values. The defaults are <b>ambientLight(128, 128, 128)</b> and
-   * <b>directionalLight(128, 128, 128, 0, 0, -1)</b>, </b>lightFalloff(1, 0, 0)</b>, and
+   * <b>directionalLight(128, 128, 128, 0, 0, -1)</b>, <b>lightFalloff(1, 0, 0)</b>, and
    * <b>lightSpecular(0, 0, 0)</b>. Lights need to be included in the <b>draw()</b> to
    * remain persistent in a looping program. Placing them in the <b>setup()</b> of a
    * looping program will cause them to only have an effect the first time
@@ -14903,7 +14904,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:lights
    * @webBrief Sets the default ambient light, directional light, falloff, and specular
-   * values.
+   * values
    * @usage web_application
    * @see PGraphics#ambientLight(float, float, float, float, float, float)
    * @see PGraphics#directionalLight(float, float, float, float, float, float)
@@ -14926,7 +14927,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Disable all lighting.
+   * @webBrief Disable all lighting
    * @usage web_application
    * @see PGraphics#lights()
    */
@@ -14949,7 +14950,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds an ambient light.
+   * @webBrief Adds an ambient light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -14994,7 +14995,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a directional light.
+   * @webBrief Adds a directional light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -15025,7 +15026,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a point light.
+   * @webBrief Adds a point light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -15060,7 +15061,7 @@ public class PApplet implements PConstants {
    * that cone.
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a spot light.
+   * @webBrief Adds a spot light
    * @usage web_application
    * @param v1            red or hue value (depending on current color mode)
    * @param v2            green or saturation value (depending on current color
@@ -15109,7 +15110,7 @@ public class PApplet implements PConstants {
    *
    * @webref lights_camera:lights
    * @webBrief Sets the falloff rates for point lights, spot lights, and ambient
-   *           lights.
+   *           lights
    * @usage web_application
    * @param constant  constant value or determining falloff
    * @param linear    linear value for determining falloff
@@ -15139,7 +15140,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Sets the specular color for lights.
+   * @webBrief Sets the specular color for lights
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -15191,7 +15192,7 @@ public class PApplet implements PConstants {
    * </p>
    *
    * @webref color:setting
-   * @webBrief Sets the color used for the background of the Processing window.
+   * @webBrief Sets the color used for the background of the Processing window
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#stroke(float)
@@ -15256,7 +15257,7 @@ public class PApplet implements PConstants {
    * 100% transparent.
    *
    * @webref color:setting
-   * @webBrief Clears the pixels within a buffer.
+   * @webBrief Clears the pixels within a buffer
    */
   public void clear() {
     if (recorder != null) recorder.clear();
@@ -15306,7 +15307,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Changes the way Processing interprets color data.
+   * @webBrief Changes the way Processing interprets color data
    * @usage web_application
    * @param mode Either RGB or HSB, corresponding to Red/Green/Blue and
    *             Hue/Saturation/Brightness
@@ -15355,7 +15356,7 @@ public class PApplet implements PConstants {
    * Extracts the alpha value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the alpha value from a color.
+   * @webBrief Extracts the alpha value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15392,7 +15393,7 @@ public class PApplet implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the red value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#green(int)
@@ -15430,7 +15431,7 @@ public class PApplet implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the green value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15468,7 +15469,7 @@ public class PApplet implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the blue value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15489,7 +15490,7 @@ public class PApplet implements PConstants {
    * Extracts the hue value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the hue value from a color.
+   * @webBrief Extracts the hue value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15509,7 +15510,7 @@ public class PApplet implements PConstants {
    * Extracts the saturation value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the saturation value from a color.
+   * @webBrief Extracts the saturation value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15530,7 +15531,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the brightness value from a color.
+   * @webBrief Extracts the brightness value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -15652,7 +15653,7 @@ public class PApplet implements PConstants {
    * pixels[] array directly.
    *
    * @webref image:pixels
-   * @webBrief Reads the color of any pixel or grabs a rectangle of pixels.
+   * @webBrief Reads the color of any pixel or grabs a rectangle of pixels
    * @usage web_application
    * @param x x-coordinate of the pixel
    * @param y y-coordinate of the pixel
@@ -15949,7 +15950,7 @@ public class PApplet implements PConstants {
    *
    *
    * @webref image:pixels
-   * @webBrief Copies a pixel or rectangle of pixels using different blending modes.
+   * @webBrief Copies a pixel or rectangle of pixels using different blending modes
    * @param src an image variable referring to the source image
    * @param sx X coordinate of the source's upper left corner
    * @param sy Y coordinate of the source's upper left corner

--- a/core/src/processing/core/PConstants.java
+++ b/core/src/processing/core/PConstants.java
@@ -135,7 +135,7 @@ public interface PConstants {
    *
    * @webref constants
    * @webBrief PI is a mathematical constant with the value
-   *           3.14159265358979323846.
+   *           3.14159265358979323846
    * @see PConstants#TWO_PI
    * @see PConstants#TAU
    * @see PConstants#HALF_PI
@@ -152,7 +152,7 @@ public interface PConstants {
    *
    * @webref constants
    * @webBrief HALF_PI is a mathematical constant with the value
-   *           1.57079632679489661923.
+   *           1.57079632679489661923
    * @see PConstants#PI
    * @see PConstants#TWO_PI
    * @see PConstants#TAU
@@ -168,7 +168,7 @@ public interface PConstants {
    * <b>sin()</b> and <b>cos()</b>.
    *
    * @webref constants
-   * @webBrief QUARTER_PI is a mathematical constant with the value 0.7853982.
+   * @webBrief QUARTER_PI is a mathematical constant with the value 0.7853982
    * @see PConstants#PI
    * @see PConstants#TWO_PI
    * @see PConstants#TAU
@@ -183,7 +183,7 @@ public interface PConstants {
    * <b>sin()</b> and <b>cos()</b>.
    *
    * @webref constants
-   * @webBrief TWO_PI is a mathematical constant with the value 6.28318530717958647693.
+   * @webBrief TWO_PI is a mathematical constant with the value 6.28318530717958647693
    * @see PConstants#PI
    * @see PConstants#TAU
    * @see PConstants#HALF_PI
@@ -199,7 +199,7 @@ public interface PConstants {
    * <b>cos()</b>.
    *
    * @webref constants
-   * @webBrief An alias for TWO_PI
+   * @webBrief An alias for <b>TWO_PI</b>
    * @see PConstants#PI
    * @see PConstants#TWO_PI
    * @see PConstants#HALF_PI

--- a/core/src/processing/core/PFont.java
+++ b/core/src/processing/core/PFont.java
@@ -72,7 +72,7 @@ import java.util.HashMap;
  * </PRE>
  *
  * @webref typography
- * @webBrief Grayscale bitmap font class used by Processing.
+ * @webBrief Grayscale bitmap font class used by Processing
  * @see PApplet#loadFont(String)
  * @see PApplet#createFont(String, float, boolean, char[])
  * @see PGraphics#textFont(PFont)
@@ -876,7 +876,7 @@ public class PFont implements PConstants {
    *
    *
    * @webref pfont
-   * @webBrief Gets a list of the fonts installed on the system.
+   * @webBrief Gets a list of the fonts installed on the system
    * @usage application
    * @brief Gets a list of the fonts installed on the system
    */

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -146,7 +146,7 @@ import processing.opengl.PShader;
  *
  * @webref rendering
  * @webBrief Main graphics and rendering context, as well as the base API
- *           implementation for processing "core".
+ *           implementation for processing "core"
  * @instanceName graphics any object of the type PGraphics
  * @usage Web &amp; Application
  * @see PApplet#createGraphics(int, int, String)
@@ -879,7 +879,7 @@ public class PGraphics extends PImage implements PConstants {
    * drawing anything.
    *
    * @webref pgraphics:method
-   * @webBrief Sets the default properties for a <b>PGraphics</b> object.
+   * @webBrief Sets the default properties for a <b>PGraphics</b> object
    */
   public void beginDraw() {  // ignore
   }
@@ -895,7 +895,7 @@ public class PGraphics extends PImage implements PConstants {
    * you're finished drawing.
    *
    * @webref pgraphics:method
-   * @webBrief Finalizes the rendering of a <b>PGraphics</b> object so that it can be shown on screen.
+   * @webBrief Finalizes the rendering of a <b>PGraphics</b> object so that it can be shown on screen
    * @brief Finalizes the rendering of a PGraphics object
    */
   public void endDraw() {  // ignore
@@ -1128,7 +1128,7 @@ public class PGraphics extends PImage implements PConstants {
    * To enable, call <b>hint(ENABLE_ASYNC_SAVEFRAME)</b>.
    *
    * @webref rendering
-   * @webBrief Set various hints and hacks for the renderer.
+   * @webBrief Set various hints and hacks for the renderer
    * @param which name of the hint to be enabled or disabled
    * @see PGraphics
    * @see PApplet#createGraphics(int, int, String, String)
@@ -1194,7 +1194,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref shape:vertex
    * @webBrief Using the <b>beginShape()</b> and <b>endShape()</b> functions allow
-   *           creating more complex forms.
+   *           creating more complex forms
    * @param kind Either POINTS, LINES, TRIANGLES, TRIANGLE_FAN, TRIANGLE_STRIP,
    *             QUADS, or QUAD_STRIP
    * @see PShape
@@ -1228,7 +1228,7 @@ public class PGraphics extends PImage implements PConstants {
    * is identical to <b>glNormal3f()</b> in OpenGL.
    *
    * @webref lights_camera:lights
-   * @webBrief Sets the current normal vector.
+   * @webBrief Sets the current normal vector
    * @param nx x direction
    * @param ny y direction
    * @param nz z direction
@@ -1297,7 +1297,7 @@ public class PGraphics extends PImage implements PConstants {
    * (0,200). The same mapping in <b>NORMAL</b> is (0,0) (1,0) (1,1) (0,1).
    *
    * @webref image:textures
-   * @webBrief Sets the coordinate space for texture mapping.
+   * @webBrief Sets the coordinate space for texture mapping
    * @param mode either IMAGE or NORMAL
    * @see PGraphics#texture(PImage)
    * @see PGraphics#textureWrap(int)
@@ -1317,7 +1317,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref image:textures
-   * @webBrief Defines if textures repeat or draw once within a texture map.
+   * @webBrief Defines if textures repeat or draw once within a texture map
    * @param wrap Either CLAMP (default) or REPEAT
    * @see PGraphics#texture(PImage)
    * @see PGraphics#textureMode(int)
@@ -1339,7 +1339,7 @@ public class PGraphics extends PImage implements PConstants {
    * shape.
    *
    * @webref image:textures
-   * @webBrief Sets a texture to be applied to vertex points.
+   * @webBrief Sets a texture to be applied to vertex points
    * @param image reference to a PImage object
    * @see PGraphics#textureMode(int)
    * @see PGraphics#textureWrap(int)
@@ -1593,7 +1593,7 @@ public class PGraphics extends PImage implements PConstants {
  * changed with <b>textureMode()</b>.
  *
  * @webref shape:vertex
- * @webBrief All shapes are constructed by connecting a series of vertices.
+ * @webBrief All shapes are constructed by connecting a series of vertices
  * @param x x-coordinate of the vertex
  * @param y y-coordinate of the vertex
  * @param z z-coordinate of the vertex
@@ -1679,7 +1679,7 @@ public class PGraphics extends PImage implements PConstants {
    * or <b>rect()</b> within.
    *
    * @webref shape:vertex
-   * @webBrief Begins recording vertices for the shape.
+   * @webBrief Begins recording vertices for the shape
    */
   public void beginContour() {
     showMissingWarning("beginContour");
@@ -1702,7 +1702,7 @@ public class PGraphics extends PImage implements PConstants {
    * or <b>rect()</b> within.
    *
    * @webref shape:vertex
-   * @webBrief Stops recording vertices for the shape.
+   * @webBrief Stops recording vertices for the shape
    */
   public void endContour() {
     showMissingWarning("endContour");
@@ -1724,7 +1724,7 @@ public class PGraphics extends PImage implements PConstants {
    * beginning and the end).
    *
    * @webref shape:vertex
-   * @webBrief the companion to <b>beginShape()</b> and may only be called after <b>beginShape()</b>.
+   * @webBrief the companion to <b>beginShape()</b> and may only be called after <b>beginShape()</b>
    * @param mode use CLOSE to close the shape
    * @see PShape
    * @see PGraphics#beginShape(int)
@@ -1758,7 +1758,7 @@ public class PGraphics extends PImage implements PConstants {
    * the value returned is null.<br />
    *
    * @webref shape
-   * @webBrief Loads geometry into a variable of type <b>PShape</b>.
+   * @webBrief Loads geometry into a variable of type <b>PShape</b>
    * @param filename name of file to load, can be .svg or .obj
    * @see PShape
    * @see PApplet#createShape()
@@ -1812,7 +1812,7 @@ public class PGraphics extends PImage implements PConstants {
    * PShape class are in the <a href="http://processing.github.io/processing-javadocs/core/">Processing Javadoc</a>.
    *
    * @webref shape
-   * @webBrief The <b>createShape()</b> function is used to define a new shape.
+   * @webBrief The <b>createShape()</b> function is used to define a new shape
    * @see PShape
    * @see PShape#endShape()
    * @see PApplet#loadShape(String)
@@ -1933,7 +1933,7 @@ public class PGraphics extends PImage implements PConstants {
   // SHADERS
 
   /**
-   * Loads a shader into the PShader object. The shader file must be
+   * Loads a shader into the <b>PShader</b> object. The shader file must be
    * loaded in the sketch's "data" folder/directory to load correctly.
    * Shaders are compatible with the P2D and P3D renderers, but not
    * with the default renderer.<br />
@@ -1951,7 +1951,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref rendering:shaders
-   * @webBrief Loads a shader into the PShader object.
+   * @webBrief Loads a shader into the <b>PShader</b> object
    * @param fragFilename name of fragment shader file
    */
   public PShader loadShader(String fragFilename) {
@@ -1976,7 +1976,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref rendering:shaders
-   * @webBrief Applies the shader specified by the parameters.
+   * @webBrief Applies the shader specified by the parameters
    * @param shader name of shader file
    */
   public void shader(PShader shader) {
@@ -1999,7 +1999,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref rendering:shaders
-   * @webBrief Restores the default shaders.
+   * @webBrief Restores the default shaders
    */
   public void resetShader() {
     showMissingWarning("resetShader");
@@ -2036,7 +2036,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref rendering
    * @webBrief Limits the rendering to the boundaries of a rectangle defined
-   * by the parameters.
+   * by the parameters
    * @param a x-coordinate of the rectangle, by default
    * @param b y-coordinate of the rectangle, by default
    * @param c width of the rectangle, by default
@@ -2086,7 +2086,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref rendering
-   * @webBrief Disables the clipping previously started by the <b>clip()</b> function.
+   * @webBrief Disables the clipping previously started by the <b>clip()</b> function
    */
   public void noClip() {
     showMissingWarning("noClip");
@@ -2135,7 +2135,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref rendering
-   * @webBrief Blends the pixels in the display window according to a defined mode.
+   * @webBrief Blends the pixels in the display window according to a defined mode
    * @param mode the blending mode to use
    */
   public void blendMode(int mode) {
@@ -2215,7 +2215,7 @@ public class PGraphics extends PImage implements PConstants {
    * for more information).
    *
  * @webref shape:vertex
- * @webBrief Specifies vertex coordinates for Bezier curves.
+ * @webBrief Specifies vertex coordinates for Bezier curves
  * @param x2 the x-coordinate of the 1st control point
  * @param y2 the y-coordinate of the 1st control point
  * @param z2 the z-coordinate of the 1st control point
@@ -2276,7 +2276,7 @@ public class PGraphics extends PImage implements PConstants {
    * reference for more information).
    *
    * @webref shape:vertex
-   * @webBrief Specifies vertex coordinates for quadratic Bezier curves.
+   * @webBrief Specifies vertex coordinates for quadratic Bezier curves
    * @param cx the x-coordinate of the control point
    * @param cy the y-coordinate of the control point
    * @param x3 the x-coordinate of the anchor point
@@ -2360,7 +2360,7 @@ public class PGraphics extends PImage implements PConstants {
    *
   *
   * @webref shape:vertex
-  * @webBrief Specifies vertex coordinates for curves.
+  * @webBrief Specifies vertex coordinates for curves
   * @param x the x-coordinate of the vertex
   * @param y the y-coordinate of the vertex
   * @see PGraphics#curve(float, float, float, float, float, float, float, float, float, float, float, float)
@@ -2521,7 +2521,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a point, a coordinate in space at the dimension of one pixel.
+   * @webBrief Draws a point, a coordinate in space at the dimension of one pixel
    * @param x x-coordinate of the point
    * @param y y-coordinate of the point
    * @see PGraphics#stroke(int)
@@ -2554,7 +2554,7 @@ public class PGraphics extends PImage implements PConstants {
    * parameter in combination with <b>size()</b> as shown in the above example.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a line (a direct path between two points) to the screen.
+   * @webBrief Draws a line (a direct path between two points) to the screen
    * @param x1 x-coordinate of the first point
    * @param y1 y-coordinate of the first point
    * @param x2 x-coordinate of the second point
@@ -2590,7 +2590,7 @@ public class PGraphics extends PImage implements PConstants {
    * second point, and the last two arguments specify the third point.
    *
    * @webref shape:2d_primitives
-   * @webBrief A triangle is a plane created by connecting three points.
+   * @webBrief A triangle is a plane created by connecting three points
    * @param x1 x-coordinate of the first point
    * @param y1 y-coordinate of the first point
    * @param x2 x-coordinate of the second point
@@ -2618,7 +2618,7 @@ public class PGraphics extends PImage implements PConstants {
    * counter-clockwise around the defined shape.
    *
    * @webref shape:2d_primitives
-   * @webBrief A quad is a quadrilateral, a four sided polygon.
+   * @webBrief A quad is a quadrilateral, a four sided polygon
    * @param x1 x-coordinate of the first corner
    * @param y1 y-coordinate of the first corner
    * @param x2 x-coordinate of the second corner
@@ -2669,7 +2669,7 @@ public class PGraphics extends PImage implements PConstants {
    * case-sensitive language.
    *
    * @webref shape:attributes
-   * @webBrief Modifies the location from which rectangles draw.
+   * @webBrief Modifies the location from which rectangles draw
    * @param mode either CORNER, CORNERS, CENTER, or RADIUS
    * @see PGraphics#rect(float, float, float, float)
    */
@@ -2696,7 +2696,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a rectangle to the screen.
+   * @webBrief Draws a rectangle to the screen
    * @param a x-coordinate of the rectangle by default
    * @param b y-coordinate of the rectangle by default
    * @param c width of the rectangle by default
@@ -2861,7 +2861,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a square to the screen.
+   * @webBrief Draws a square to the screen
    * @param x x-coordinate of the rectangle by default
    * @param y y-coordinate of the rectangle by default
    * @param extent width and height of the rectangle by default
@@ -2906,7 +2906,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref shape:attributes
    * @webBrief The origin of the ellipse is modified by the <b>ellipseMode()</b>
-   *           function.
+   *           function
    * @param mode either CENTER, RADIUS, CORNER, or CORNERS
    * @see PApplet#ellipse(float, float, float, float)
    * @see PApplet#arc(float, float, float, float, float, float)
@@ -2924,7 +2924,7 @@ public class PGraphics extends PImage implements PConstants {
    * be changed with the <b>ellipseMode()</b> function.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws an ellipse (oval) in the display window.
+   * @webBrief Draws an ellipse (oval) in the display window
    * @param a x-coordinate of the ellipse
    * @param b y-coordinate of the ellipse
    * @param c width of the ellipse by default
@@ -2991,7 +2991,7 @@ public class PGraphics extends PImage implements PConstants {
    * arc yourself with <b>beginShape()</b>/<b>endShape()</b> or a <b>PShape</b>.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws an arc in the display window.
+   * @webBrief Draws an arc in the display window
    * @param a     x-coordinate of the arc's ellipse
    * @param b     y-coordinate of the arc's ellipse
    * @param c     width of the arc's ellipse by default
@@ -3077,7 +3077,7 @@ public class PGraphics extends PImage implements PConstants {
    * function.
    *
    * @webref shape:2d_primitives
-   * @webBrief Draws a circle to the screen.
+   * @webBrief Draws a circle to the screen
    * @param x x-coordinate of the ellipse
    * @param y y-coordinate of the ellipse
    * @param extent width and height of the ellipse by default
@@ -3095,12 +3095,12 @@ public class PGraphics extends PImage implements PConstants {
 
   /**
    *
-   * A box is an extruded rectangle. A box with equal dimension on all sides
+   * A box is an extruded <b>rectangle</b>. A box with equal dimension on all sides
    * is a cube.
    *
    *
    * @webref shape:3d_primitives
-   * @webBrief A box is an extruded rectangle.
+   * @webBrief A box is an extruded <b>rectangle</b>
    * @param size dimension of the box in all dimensions (creates a cube)
    * @see PGraphics#sphere(float)
    */
@@ -3198,7 +3198,7 @@ public class PGraphics extends PImage implements PConstants {
    * @param res number of segments (minimum 3) used per full circle revolution
    * @webref shape:3d_primitives
    * @webBrief Controls the detail used to render a sphere by adjusting the number of
-   * vertices of the sphere mesh.
+   * vertices of the sphere mesh
    * @see PGraphics#sphere(float)
    */
   public void sphereDetail(int res) {
@@ -3279,7 +3279,7 @@ public class PGraphics extends PImage implements PConstants {
    * </PRE>
    *
    * @webref shape:3d_primitives
-   * @webBrief A sphere is a hollow ball made from tessellated triangles.
+   * @webBrief A sphere is a hollow ball made from tessellated triangles
    * @param r the radius of the sphere
    * @see PGraphics#sphereDetail(int)
    */
@@ -3385,7 +3385,7 @@ public class PGraphics extends PImage implements PConstants {
    * endShape();</PRE>
    *
    * @webref shape:curves
-   * @webBrief Evaluates the Bezier at point t for points a, b, c, d.
+   * @webBrief Evaluates the Bezier at point t for points a, b, c, d
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -3410,7 +3410,7 @@ public class PGraphics extends PImage implements PConstants {
    * Code submitted by Dave Bollinger (davbol) for release 0136.
    *
    * @webref shape:curves
-   * @webBrief Calculates the tangent of a point on a Bezier curve.
+   * @webBrief Calculates the tangent of a point on a Bezier curve
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -3449,7 +3449,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Sets the resolution at which Beziers display.
+   * @webBrief Sets the resolution at which Beziers display
    * @param detail resolution of the curves
    * @see PGraphics#curve(float, float, float, float, float, float, float, float,
    *      float, float, float, float)
@@ -3520,7 +3520,7 @@ public class PGraphics extends PImage implements PConstants {
    * <PRE>bezier(x1, y1, cx, cy, cx, cy, x2, y2);</PRE>
    *
    * @webref shape:curves
-   * @webBrief Draws a Bezier curve on the screen.
+   * @webBrief Draws a Bezier curve on the screen
    * @param x1 coordinates for the first anchor point
    * @param y1 coordinates for the first anchor point
    * @param z1 coordinates for the first anchor point
@@ -3567,7 +3567,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Evaluates the curve at point t for points a, b, c, d.
+   * @webBrief Evaluates the curve at point t for points a, b, c, d
    * @param a coordinate of first control point
    * @param b coordinate of first point on the curve
    * @param c coordinate of second point on the curve
@@ -3604,7 +3604,7 @@ public class PGraphics extends PImage implements PConstants {
    * Code thanks to Dave Bollinger (Bug #715)
    *
    * @webref shape:curves
-   * @webBrief Calculates the tangent of a point on a curve.
+   * @webBrief Calculates the tangent of a point on a curve
    * @param a coordinate of first point on the curve
    * @param b coordinate of first control point
    * @param c coordinate of second control point
@@ -3638,7 +3638,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:curves
-   * @webBrief Sets the resolution at which curves display.
+   * @webBrief Sets the resolution at which curves display
    * @param detail resolution of the curves
    * @see PGraphics#curve(float, float, float, float, float, float, float, float, float, float, float, float)
    * @see PGraphics#curveVertex(float, float)
@@ -3663,7 +3663,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref shape:curves
    * @webBrief Modifies the quality of forms created with <b>curve()</b> and
-   *           <b>curveVertex()</b>.
+   *           <b>curveVertex()</b>
    * @param tightness amount of deformation from the original vertices
    * @see PGraphics#curve(float, float, float, float, float, float, float, float,
    *      float, float, float, float)
@@ -3756,7 +3756,7 @@ public class PGraphics extends PImage implements PConstants {
    * </PRE>
    *
    * @webref shape:curves
-   * @webBrief Draws a curved line on the screen.
+   * @webBrief Draws a curved line on the screen
    * @param x1 coordinates for the beginning control point
    * @param y1 coordinates for the beginning control point
    * @param x2 coordinates for the first point
@@ -3894,7 +3894,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref image:loading_displaying
-   * @webBrief Modifies the location from which images draw.
+   * @webBrief Modifies the location from which images draw
    * @param mode either CORNER, CORNERS, or CENTER
    * @see PApplet#loadImage(String, String)
    * @see PImage
@@ -3933,7 +3933,7 @@ public class PGraphics extends PImage implements PConstants {
    * renderer, smooth() will also improve image quality of resized images.
    *
    * @webref image:loading_displaying
-   * @webBrief Displays images to the screen.
+   * @webBrief Displays images to the screen
    * @param img the image to display
    * @param a   x-coordinate of the image by default
    * @param b   y-coordinate of the image by default
@@ -4106,7 +4106,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:loading_displaying
-   * @webBrief Modifies the location from which shapes draw.
+   * @webBrief Modifies the location from which shapes draw
    * @param mode either CORNER, CORNERS, CENTER
    * @see PShape
    * @see PGraphics#shape(PShape)
@@ -4150,7 +4150,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:loading_displaying
-   * @webBrief Displays shapes to the screen.
+   * @webBrief Displays shapes to the screen
    * @param shape the shape to display
    * @param x     x-coordinate of the shape
    * @param y     y-coordinate of the shape
@@ -4326,7 +4326,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the current alignment for drawing text.
+   * @webBrief Sets the current alignment for drawing text
    * @param alignX horizontal alignment, either LEFT, CENTER, or RIGHT
    * @param alignY vertical alignment, either TOP, BOTTOM, CENTER, or BASELINE
    * @see PApplet#loadFont(String)
@@ -4349,7 +4349,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:metrics
-   * @webBrief Returns ascent of the current font at its current size.
+   * @webBrief Returns ascent of the current font at its current size
    * @see PGraphics#textDescent()
    */
   public float textAscent() {
@@ -4366,7 +4366,7 @@ public class PGraphics extends PImage implements PConstants {
    * useful for determining the height of the font below the baseline.
    *
    * @webref typography:metrics
-   * @webBrief Returns descent of the current font at its current size.
+   * @webBrief Returns descent of the current font at its current size
    * @see PGraphics#textAscent()
    */
   public float textDescent() {
@@ -4398,7 +4398,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref typography:loading_displaying
    * @webBrief Sets the current font that will be drawn with the <b>text()</b>
-   *           function.
+   *           function
    * @param which any variable of the type PFont
    * @see PApplet#createFont(String, float, boolean)
    * @see PApplet#loadFont(String)
@@ -4488,7 +4488,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the spacing between lines of text in units of pixels.
+   * @webBrief Sets the spacing between lines of text in units of pixels
    * @param leading the size in pixels for spacing between lines
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -4520,7 +4520,7 @@ public class PGraphics extends PImage implements PConstants {
    * <b>beginRaw()</b>.
    *
    * @webref typography:attributes
-   * @webBrief Sets the way text draws to the screen.
+   * @webBrief Sets the way text draws to the screen
    * @param mode either MODEL or SHAPE
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -4565,7 +4565,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Sets the current font size.
+   * @webBrief Sets the current font size
    * @param size the size of the letters in units of pixels
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -4628,7 +4628,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:attributes
-   * @webBrief Calculates and returns the width of any character or text string.
+   * @webBrief Calculates and returns the width of any character or text string
    * @param str the String of characters to measure
    * @see PApplet#loadFont(String)
    * @see PFont#PFont
@@ -4715,7 +4715,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref typography:loading_displaying
-   * @webBrief Draws text to the screen.
+   * @webBrief Draws text to the screen
    * @param c the alphanumeric character to be displayed
    * @param x x-coordinate of text
    * @param y y-coordinate of text
@@ -5319,7 +5319,7 @@ public class PGraphics extends PImage implements PConstants {
    * @webref structure
    * @webBrief The <b>push()</b> function saves the current drawing style
    * settings and transformations, while <b>pop()</b> restores these
-   * settings.
+   * settings
    * @see PGraphics#pop()
    */
   public void push() {
@@ -5356,7 +5356,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref structure
    * @webBrief The <b>pop()</b> function restores the previous drawing style
-   * settings and transformations after <b>push()</b> has changed them.
+   * settings and transformations after <b>push()</b> has changed them
    * @see PGraphics#push()
    */
   public void pop() {
@@ -5384,7 +5384,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Pushes the current transformation matrix onto the matrix stack.
+   * @webBrief Pushes the current transformation matrix onto the matrix stack
    * @see PGraphics#popMatrix()
    * @see PGraphics#translate(float, float, float)
    * @see PGraphics#scale(float)
@@ -5410,7 +5410,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Pops the current transformation matrix off the matrix stack.
+   * @webBrief Pops the current transformation matrix off the matrix stack
    * @see PGraphics#pushMatrix()
    */
   public void popMatrix() {
@@ -5443,7 +5443,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Specifies an amount to displace objects within the display window.
+   * @webBrief Specifies an amount to displace objects within the display window
    * @param x left/right translation
    * @param y up/down translation
    * @see PGraphics#popMatrix()
@@ -5487,7 +5487,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Rotates a shape the amount specified by the <b>angle</b> parameter.
+   * @webBrief Rotates a shape the amount specified by the <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5520,7 +5520,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the x-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5553,7 +5553,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the y-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5586,7 +5586,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Rotates a shape around the z-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of rotation specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5631,7 +5631,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Increases or decreases the size of a shape by expanding and
-   *           contracting vertices.
+   *           contracting vertices
    * @param s percentage to scale the object
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
@@ -5689,7 +5689,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Shears a shape around the x-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of shear specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5723,7 +5723,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Shears a shape around the y-axis the amount specified by the
-   * <b>angle</b> parameter.
+   * <b>angle</b> parameter
    * @param angle angle of shear specified in radians
    * @see PGraphics#popMatrix()
    * @see PGraphics#pushMatrix()
@@ -5749,7 +5749,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref transform
-   * @webBrief Replaces the current matrix with the identity matrix.
+   * @webBrief Replaces the current matrix with the identity matrix
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
    * @see PGraphics#applyMatrix(PMatrix)
@@ -5769,7 +5769,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Multiplies the current matrix by the one specified through the
-   * parameters.
+   * parameters
    * @source
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
@@ -5900,7 +5900,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref transform
    * @webBrief Prints the current matrix to the Console (the text window at the bottom
-   * of Processing).
+   * of Processing)
    * @see PGraphics#pushMatrix()
    * @see PGraphics#popMatrix()
    * @see PGraphics#resetMatrix()
@@ -5937,7 +5937,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief The <b>beginCamera()</b> and <b>endCamera()</b> functions enable
-   * advanced customization of the camera space.
+   * advanced customization of the camera space
    * @see PGraphics#camera()
    * @see PGraphics#endCamera()
    * @see PGraphics#applyMatrix(PMatrix)
@@ -5958,7 +5958,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief The <b>beginCamera()</b> and <b>endCamera()</b> functions enable
-   * advanced customization of the camera space.
+   * advanced customization of the camera space
    * @see PGraphics#beginCamera()
    * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
    */
@@ -5980,7 +5980,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Sets the position of the camera.
+   * @webBrief Sets the position of the camera
    * @see PGraphics#beginCamera()
    * @see PGraphics#endCamera()
    * @see PGraphics#frustum(float, float, float, float, float, float)
@@ -6013,7 +6013,7 @@ public class PGraphics extends PImage implements PConstants {
    *
  * @webref lights_camera:camera
  * @webBrief Prints the current camera matrix to the Console (the text window at the
- * bottom of Processing).
+ * bottom of Processing)
  * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
  */
   public void printCamera() {
@@ -6039,7 +6039,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief Sets an orthographic projection and defines a parallel clipping
-   *           volume.
+   *           volume
    */
   public void ortho() {
     showMissingWarning("ortho");
@@ -6082,7 +6082,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:camera
    * @webBrief Sets a perspective projection applying foreshortening, making distant
-   * objects appear smaller than closer ones.
+   * objects appear smaller than closer ones
    */
   public void perspective() {
     showMissingWarning("perspective");
@@ -6122,7 +6122,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Sets a perspective matrix defined through the parameters.
+   * @webBrief Sets a perspective matrix defined through the parameters
    * @param left   left coordinate of the clipping plane
    * @param right  right coordinate of the clipping plane
    * @param bottom bottom coordinate of the clipping plane
@@ -6149,7 +6149,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:camera
-   * @webBrief Prints the current projection matrix to the Console.
+   * @webBrief Prints the current projection matrix to the Console
    * @see PGraphics#camera(float, float, float, float, float, float, float, float, float)
    */
   public void printProjection() {
@@ -6171,7 +6171,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the X value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @see PGraphics#screenY(float, float, float)
@@ -6191,7 +6191,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the Y value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @see PGraphics#screenX(float, float, float)
@@ -6230,7 +6230,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:coordinates
    * @webBrief Takes a three-dimensional X, Y, Z position and returns the Z value for
-   * where it will appear on a (two-dimensional) screen.
+   * where it will appear on a (two-dimensional) screen
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -6260,7 +6260,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -6290,7 +6290,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -6320,7 +6320,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:coordinates
-   * @webBrief Returns the three-dimensional X, Y, Z position in model space.
+   * @webBrief Returns the three-dimensional X, Y, Z position in model space
    * @param x 3D x-coordinate to be mapped
    * @param y 3D y-coordinate to be mapped
    * @param z 3D z-coordinate to be mapped
@@ -6357,7 +6357,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref structure
-   * @webBrief Saves the current style settings and <b>popStyle()</b> restores the prior settings.
+   * @webBrief Saves the current style settings and <b>popStyle()</b> restores the prior settings
    * @see PGraphics#popStyle()
    */
   public void pushStyle() {
@@ -6547,7 +6547,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref shape:attributes
    * @webBrief Sets the width of the stroke used for lines, points, and the border
-   *           around shapes.
+   *           around shapes
    * @param weight the weight (in pixels) of the stroke
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeJoin(int)
@@ -6565,7 +6565,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref shape:attributes
-   * @webBrief Sets the style of the joints which connect line segments.
+   * @webBrief Sets the style of the joints which connect line segments
    * @param join either MITER, BEVEL, ROUND
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeWeight(float)
@@ -6585,7 +6585,7 @@ public class PGraphics extends PImage implements PConstants {
    * <b>strokeCap(SQUARE)</b> (no cap) causes points to become invisible.
    *
    * @webref shape:attributes
-   * @webBrief Sets the style for rendering line endings.
+   * @webBrief Sets the style for rendering line endings
    * @param cap either SQUARE, PROJECT, or ROUND
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#strokeWeight(float)
@@ -6610,7 +6610,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Disables drawing the stroke (outline).
+   * @webBrief Disables drawing the stroke (outline)
    * @see PGraphics#stroke(int, float)
    * @see PGraphics#fill(float, float, float, float)
    * @see PGraphics#noFill()
@@ -6644,7 +6644,7 @@ public class PGraphics extends PImage implements PConstants {
    * performance). See the hint() documentation for more details.
    *
    * @webref color:setting
-   * @webBrief Sets the color used to draw lines and borders around shapes.
+   * @webBrief Sets the color used to draw lines and borders around shapes
    * @param rgb color value in hexadecimal notation
    * @see PGraphics#noStroke()
    * @see PGraphics#strokeWeight(float)
@@ -6732,7 +6732,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref image:loading_displaying
    * @webBrief Removes the current fill value for displaying images and reverts to
-   * displaying images with their original hues.
+   * displaying images with their original hues
    * @usage web_application
    * @see PGraphics#tint(float, float, float, float)
    * @see PGraphics#image(PImage, float, float, float, float)
@@ -6769,7 +6769,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref image:loading_displaying
-   * @webBrief Sets the fill value for displaying images.
+   * @webBrief Sets the fill value for displaying images
    * @usage web_application
    * @param rgb color value in hexadecimal notation
    * @see PGraphics#noTint()
@@ -6849,7 +6849,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Disables filling geometry.
+   * @webBrief Disables filling geometry
    * @usage web_application
    * @see PGraphics#fill(float, float, float, float)
    * @see PGraphics#stroke(int, float)
@@ -6884,7 +6884,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Sets the color used to fill shapes.
+   * @webBrief Sets the color used to fill shapes
    * @usage web_application
    * @param rgb color variable or hex value
    * @see PGraphics#noFill()
@@ -6972,7 +6972,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:material_properties
-   * @webBrief Sets the ambient reflectance for shapes drawn to the screen.
+   * @webBrief Sets the ambient reflectance for shapes drawn to the screen
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#emissive(float, float, float)
@@ -7029,7 +7029,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:material_properties
    * @webBrief Sets the specular color of the materials used for shapes drawn to the
-   * screen, which sets the color of highlights.
+   * screen, which sets the color of highlights
    * @usage web_application
    * @param rgb color to set
    * @see PGraphics#lightSpecular(float, float, float)
@@ -7088,7 +7088,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:material_properties
-   * @webBrief Sets the amount of gloss in the surface of shapes.
+   * @webBrief Sets the amount of gloss in the surface of shapes
    * @usage web_application
    * @param shine degree of shininess
    * @see PGraphics#emissive(float, float, float)
@@ -7109,7 +7109,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:material_properties
    * @webBrief Sets the emissive color of the material used for drawing shapes drawn to
-   * the screen.
+   * the screen
    * @usage web_application
    * @param rgb color to set
    * @see PGraphics#ambient(float, float, float)
@@ -7179,7 +7179,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:lights
    * @webBrief Sets the default ambient light, directional light, falloff, and specular
-   * values.
+   * values
    * @usage web_application
    * @see PGraphics#ambientLight(float, float, float, float, float, float)
    * @see PGraphics#directionalLight(float, float, float, float, float, float)
@@ -7200,7 +7200,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Disable all lighting.
+   * @webBrief Disable all lighting
    * @usage web_application
    * @see PGraphics#lights()
    */
@@ -7221,7 +7221,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds an ambient light.
+   * @webBrief Adds an ambient light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -7262,7 +7262,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a directional light.
+   * @webBrief Adds a directional light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -7291,7 +7291,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a point light.
+   * @webBrief Adds a point light
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -7324,7 +7324,7 @@ public class PGraphics extends PImage implements PConstants {
    * that cone.
    *
    * @webref lights_camera:lights
-   * @webBrief Adds a spot light.
+   * @webBrief Adds a spot light
    * @usage web_application
    * @param v1            red or hue value (depending on current color mode)
    * @param v2            green or saturation value (depending on current color
@@ -7371,7 +7371,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref lights_camera:lights
    * @webBrief Sets the falloff rates for point lights, spot lights, and ambient
-   *           lights.
+   *           lights
    * @usage web_application
    * @param constant  constant value or determining falloff
    * @param linear    linear value for determining falloff
@@ -7399,7 +7399,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref lights_camera:lights
-   * @webBrief Sets the specular color for lights.
+   * @webBrief Sets the specular color for lights
    * @usage web_application
    * @param v1 red or hue value (depending on current color mode)
    * @param v2 green or saturation value (depending on current color mode)
@@ -7456,7 +7456,7 @@ public class PGraphics extends PImage implements PConstants {
    * </p>
    *
    * @webref color:setting
-   * @webBrief Sets the color used for the background of the Processing window.
+   * @webBrief Sets the color used for the background of the Processing window
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#stroke(float)
@@ -7552,7 +7552,7 @@ public class PGraphics extends PImage implements PConstants {
    * 100% transparent.
    *
    * @webref color:setting
-   * @webBrief Clears the pixels within a buffer.
+   * @webBrief Clears the pixels within a buffer
    */
   public void clear() {
     background(0, 0, 0, 0);
@@ -7658,7 +7658,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:setting
-   * @webBrief Changes the way Processing interprets color data.
+   * @webBrief Changes the way Processing interprets color data
    * @usage web_application
    * @param mode Either RGB or HSB, corresponding to Red/Green/Blue and
    *             Hue/Saturation/Brightness
@@ -7995,7 +7995,7 @@ public class PGraphics extends PImage implements PConstants {
    * Extracts the alpha value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the alpha value from a color.
+   * @webBrief Extracts the alpha value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8034,7 +8034,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the red value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#green(int)
@@ -8074,7 +8074,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the green value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8114,7 +8114,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    * @webref color:creating_reading
    * @webBrief Extracts the blue value from a color, scaled to match current
-   *           <b>colorMode()</b>.
+   *           <b>colorMode()</b>
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8137,7 +8137,7 @@ public class PGraphics extends PImage implements PConstants {
    * Extracts the hue value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the hue value from a color.
+   * @webBrief Extracts the hue value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8162,7 +8162,7 @@ public class PGraphics extends PImage implements PConstants {
    * Extracts the saturation value from a color.
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the saturation value from a color.
+   * @webBrief Extracts the saturation value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8188,7 +8188,7 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:creating_reading
-   * @webBrief Extracts the brightness value from a color.
+   * @webBrief Extracts the brightness value from a color
    * @usage web_application
    * @param rgb any value of the color datatype
    * @see PGraphics#red(int)
@@ -8229,8 +8229,8 @@ public class PGraphics extends PImage implements PConstants {
    *
    *
    * @webref color:creating_reading
-   * @webBrief Calculates a color or colors between two color at a specific
-   *           increment.
+   * @webBrief Calculates a <b>color</b> or <b>colors</b> between two <b>colors</b> at a specific
+   *           increment
    * @usage web_application
    * @param c1  interpolate from this color
    * @param c2  interpolate to this color

--- a/core/src/processing/core/PGraphics.java
+++ b/core/src/processing/core/PGraphics.java
@@ -871,7 +871,7 @@ public class PGraphics extends PImage implements PConstants {
 
   /**
    *
-   * Sets the default properties for a PGraphics object. It should be called
+   * Sets the default properties for a <b>PGraphics</b> object. It should be called
    * before anything is drawn into the object.
    *
    * <h3>Advanced</h3>
@@ -879,7 +879,7 @@ public class PGraphics extends PImage implements PConstants {
    * drawing anything.
    *
    * @webref pgraphics:method
-   * @webBrief Sets the default properties for a PGraphics object.
+   * @webBrief Sets the default properties for a <b>PGraphics</b> object.
    */
   public void beginDraw() {  // ignore
   }
@@ -887,7 +887,7 @@ public class PGraphics extends PImage implements PConstants {
 
   /**
    *
-   * Finalizes the rendering of a PGraphics object so that it can be shown on screen.
+   * Finalizes the rendering of a <b>PGraphics</b> object so that it can be shown on screen.
    *
    * <h3>Advanced</h3>
    * <p/>
@@ -895,7 +895,7 @@ public class PGraphics extends PImage implements PConstants {
    * you're finished drawing.
    *
    * @webref pgraphics:method
-   * @webBrief Finalizes the rendering of a PGraphics object so that it can be shown on screen.
+   * @webBrief Finalizes the rendering of a <b>PGraphics</b> object so that it can be shown on screen.
    * @brief Finalizes the rendering of a PGraphics object
    */
   public void endDraw() {  // ignore
@@ -1068,64 +1068,64 @@ public class PGraphics extends PImage implements PConstants {
    * manner across renderers. Many options will often graduate to standard
    * features instead of hints over time.
    * <br/> <br/>
-   * hint(ENABLE_OPENGL_4X_SMOOTH) - Enable 4x anti-aliasing for P3D. This
+   * <b>hint(ENABLE_OPENGL_4X_SMOOTH)</b>- Enable 4x anti-aliasing for P3D. This
    * can help force anti-aliasing if it has not been enabled by the user. On
    * some graphics cards, this can also be set by the graphics driver's
    * control panel, however not all cards make this available. This hint must
-   * be called immediately after the size() command because it resets the
-   * renderer, obliterating any settings and anything drawn (and like size(),
+   * be called immediately after the <b>size()</b> command because it resets the
+   * renderer, obliterating any settings and anything drawn (and like <b>size()</b>,
    * re-running the code that came before it again).
    * <br/> <br/>
-   * hint(DISABLE_OPENGL_2X_SMOOTH) - In Processing 1.0, Processing always
+   * <b>hint(DISABLE_OPENGL_2X_SMOOTH)</b> - In Processing 1.0, Processing always
    * enables 2x smoothing when the P3D renderer is used. This hint disables
    * the default 2x smoothing and returns the smoothing behavior found in
-   * earlier releases, where smooth() and noSmooth() could be used to enable
+   * earlier releases, where <b>smooth()</b> and <b>noSmooth()</b> could be used to enable
    * and disable smoothing, though the quality was inferior.
    * <br/> <br/>
-   * hint(ENABLE_NATIVE_FONTS) - Use the native version fonts when they are
+   * <b>hint(ENABLE_NATIVE_FONTS)</b> - Use the native version fonts when they are
    * installed, rather than the bitmapped version from a .vlw file. This is
    * useful with the default (or JAVA2D) renderer setting, as it will improve
    * font rendering speed. This is not enabled by default, because it can be
    * misleading while testing because the type will look great on your
    * machine (because you have the font installed) but lousy on others'
    * machines if the identical font is unavailable. This option can only be
-   * set per-sketch, and must be called before any use of textFont().
+   * set per-sketch, and must be called before any use of <b>textFont()</b>.
    * <br/> <br/>
-   * hint(DISABLE_DEPTH_TEST) - Disable the zbuffer, allowing you to draw on
+   * <b>hint(DISABLE_DEPTH_TEST)</b> - Disable the zbuffer, allowing you to draw on
    * top of everything at will. When depth testing is disabled, items will be
    * drawn to the screen sequentially, like a painting. This hint is most
    * often used to draw in 3D, then draw in 2D on top of it (for instance, to
    * draw GUI controls in 2D on top of a 3D interface). Starting in release
    * 0149, this will also clear the depth buffer. Restore the default with
-   * hint(ENABLE_DEPTH_TEST), but note that with the depth buffer cleared,
-   * any 3D drawing that happens later in draw() will ignore existing shapes
+   * <b>hint(ENABLE_DEPTH_TEST)</b>, but note that with the depth buffer cleared,
+   * any 3D drawing that happens later in <b>draw()</b> will ignore existing shapes
    * on the screen.
    * <br/> <br/>
-   * hint(ENABLE_DEPTH_SORT) - Enable primitive z-sorting of triangles and
+   * <b>hint(ENABLE_DEPTH_SORT)</b> - Enable primitive z-sorting of triangles and
    * lines in P3D and OPENGL. This can slow performance considerably, and the
-   * algorithm is not yet perfect. Restore the default with hint(DISABLE_DEPTH_SORT).
+   * algorithm is not yet perfect. Restore the default with <b>hint(DISABLE_DEPTH_SORT)</b>.
    * <br/> <br/>
-   * hint(DISABLE_OPENGL_ERROR_REPORT) - Speeds up the P3D renderer setting
-   * by not checking for errors while running. Undo with hint(ENABLE_OPENGL_ERROR_REPORT).
+   * <b>hint(DISABLE_OPENGL_ERROR_REPORT)</b> - Speeds up the P3D renderer setting
+   * by not checking for errors while running. Undo with <b>hint(ENABLE_OPENGL_ERROR_REPORT)</b>.
    * <br/> <br/>
-   * hint(ENABLE_BUFFER_READING) - Depth and stencil buffers in P2D/P3D will be
+   * <b>hint(ENABLE_BUFFER_READING)</b> - Depth and stencil buffers in P2D/P3D will be
    * down-sampled to make PGL#readPixels work with multisampling. Enabling this
    * introduces some overhead, so if you experience bad performance, disable
-   * multisampling with noSmooth() instead. This hint is not intended to be
-   * enabled and disabled repeatedly, so call this once in setup() or after
+   * multisampling with <b>noSmooth()</b> instead. This hint is not intended to be
+   * enabled and disabled repeatedly, so call this once in <b>setup()</b> or after
    * creating your PGraphics2D/3D. You can restore the default with
-   * hint(DISABLE_BUFFER_READING) if you don't plan to read depth from
-   * this PGraphics anymore.
+   * <b>hint(DISABLE_BUFFER_READING)</b> if you don't plan to read depth from
+   * this <b>PGraphics</b> anymore.
    * <br/> <br/>
-   * hint(ENABLE_KEY_REPEAT) - Auto-repeating key events are discarded
+   * <b>hint(ENABLE_KEY_REPEAT)</b> - Auto-repeating key events are discarded
    * by default (works only in P2D/P3D); use this hint to get all the key events
-   * (including auto-repeated). Call hint(DISABLE_KEY_REPEAT) to get events
+   * (including auto-repeated). Call <b>hint(DISABLE_KEY_REPEAT)</b> to get events
    * only when the key goes physically up or down.
    * <br/> <br/>
-   * hint(DISABLE_ASYNC_SAVEFRAME) - P2D/P3D only - save() and saveFrame()
+   * <b>hint(DISABLE_ASYNC_SAVEFRAME)</b> - P2D/P3D only - <b>save()</b> and <b>saveFrame()</b>
    * will not use separate threads for saving and will block until the image
    * is written to the drive. This was the default behavior in 3.0b7 and before.
-   * To enable, call hint(ENABLE_ASYNC_SAVEFRAME).
+   * To enable, call <b>hint(ENABLE_ASYNC_SAVEFRAME)</b>.
    *
    * @webref rendering
    * @webBrief Set various hints and hacks for the renderer.
@@ -2107,15 +2107,15 @@ public class PGraphics extends PImage implements PConstants {
    * channel of (A) and (B) independently. The red channel is compared with
    * red, green with green, and blue with blue.<br />
    * <br />
-   * BLEND - linear interpolation of colors: C = A*factor + B. This is the default.<br />
+   * BLEND - linear interpolation of colors: <b>C = A*factor + B</b>. This is the default.<br />
    * <br />
-   * ADD - additive blending with white clip: C = min(A*factor + B, 255)<br />
+   * ADD - additive blending with white clip: <b>C = min(A*factor + B, 255)</b><br />
    * <br />
-   * SUBTRACT - subtractive blending with black clip: C = max(B - A*factor, 0)<br />
+   * SUBTRACT - subtractive blending with black clip: <b>C = max(B - A*factor, 0)</b><br />
    * <br />
-   * DARKEST - only the darkest color succeeds: C = min(A*factor, B)<br />
+   * DARKEST - only the darkest color succeeds: <b>C = min(A*factor, B)</b><br />
    * <br />
-   * LIGHTEST - only the lightest color succeeds: C = max(A*factor, B)<br />
+   * LIGHTEST - only the lightest color succeeds: <b>C = max(A*factor, B)</b><br />
    * <br />
    * DIFFERENCE - subtract colors from underlying image.<br />
    * <br />
@@ -5764,7 +5764,7 @@ public class PGraphics extends PImage implements PConstants {
    * Multiplies the current matrix by the one specified through the
    * parameters. This is very slow because it will try to calculate the
    * inverse of the transform, so avoid it whenever possible. The equivalent
-   * function in OpenGL is glMultMatrix().
+   * function in OpenGL is <b>glMultMatrix()</b>.
    *
    *
    * @webref transform
@@ -6034,7 +6034,7 @@ public class PGraphics extends PImage implements PConstants {
    * the clipping volume where left and right are the minimum and maximum x
    * values, top and bottom are the minimum and maximum y values, and near and far
    * are the minimum and maximum z values. If no parameters are given, the default
-   * is used: ortho(-width/2, width/2, -height/2, height/2).
+   * is used: <b>ortho(-width/2, width/2, -height/2, height/2)</b>.
    *
    *
    * @webref lights_camera:camera
@@ -6076,8 +6076,8 @@ public class PGraphics extends PImage implements PConstants {
    * accurately than orthographic projection. The version of perspective
    * without parameters sets the default perspective and the version with
    * four parameters allows the programmer to set the area precisely. The
-   * default values are: perspective(PI/3.0, width/height, cameraZ/10.0,
-   * cameraZ*10.0) where cameraZ is ((height/2.0) / tan(PI*60.0/360.0));
+   * default values are: <b>perspective(PI/3.0, width/height, cameraZ/10.0,
+   * cameraZ*10.0)</b> where cameraZ is <b>((height/2.0) / tan(PI*60.0/360.0))</b>
    *
    *
    * @webref lights_camera:camera
@@ -6254,8 +6254,8 @@ public class PGraphics extends PImage implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -6284,8 +6284,8 @@ public class PGraphics extends PImage implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -6314,8 +6314,8 @@ public class PGraphics extends PImage implements PConstants {
    * In the example, the <b>modelX()</b>, <b>modelY()</b>, and
    * <b>modelZ()</b> functions record the location of a box in space after
    * being placed using a series of translate and rotate commands. After
-   * popMatrix() is called, those transformations no longer apply, but the
-   * (x, y, z) coordinate returned by the model functions is used to place
+   * <b>popMatrix()</b> is called, those transformations no longer apply, but the
+   * <b>(x, y, z)</b> coordinate returned by the model functions is used to place
    * another box in the same location.
    *
    *
@@ -6350,10 +6350,10 @@ public class PGraphics extends PImage implements PConstants {
    * <br /><br />
    * The style information controlled by the following functions are included
    * in the style:
-   * fill(), stroke(), tint(), strokeWeight(), strokeCap(), strokeJoin(),
-   * imageMode(), rectMode(), ellipseMode(), shapeMode(), colorMode(),
-   * textAlign(), textFont(), textMode(), textSize(), textLeading(),
-   * emissive(), specular(), shininess(), ambient()
+   * <b>fill()<b>, <b>stroke()</b>, <b>tint()</b>, <b>strokeWeight()</b>, <b>strokeCap()</b>,<b>strokeJoin()</b>,
+   * <b>imageMode()</b>, <b>rectMode()</b>, <b>ellipseMode()</b>, <b>shapeMode()</b>, <b>colorMode()</b>,
+   * <b>textAlign()</b>, <b>textFont()</b>, <b>textMode()</b>, <b>textSize()</b>, <b>textLeading()</b>,
+   * <b>emissive()</b>, <b>specular()</b>, <b>shininess()</b>, <b>ambient()</b>
    *
    *
    * @webref structure
@@ -7169,10 +7169,10 @@ public class PGraphics extends PImage implements PConstants {
   /**
    *
    * Sets the default ambient light, directional light, falloff, and specular
-   * values. The defaults are ambientLight(128, 128, 128) and
-   * directionalLight(128, 128, 128, 0, 0, -1), lightFalloff(1, 0, 0), and
-   * lightSpecular(0, 0, 0). Lights need to be included in the draw() to
-   * remain persistent in a looping program. Placing them in the setup() of a
+   * values. The defaults are <b>ambientLight(128, 128, 128)</b> and
+   * <b>directionalLight(128, 128, 128, 0, 0, -1)</b>, <b>lightFalloff(1, 0, 0)</b>, and
+   * <b>lightSpecular(0, 0, 0)</b>. Lights need to be included in the <b>draw()</b> to
+   * remain persistent in a looping program. Placing them in the <b>setup()</b> of a
    * looping program will cause them to only have an effect the first time
    * through the loop.
    *
@@ -8223,7 +8223,7 @@ public class PGraphics extends PImage implements PConstants {
    * equal to the first point, 0.1 is very near the first point, 0.5 is halfway in
    * between, etc. <br />
    * An amount below 0 will be treated as 0. Likewise, amounts above 1 will be
-   * capped at 1. This is different from the behavior of lerp(), but necessary
+   * capped at 1. This is different from the behavior of <b>lerp()</b>, but necessary
    * because otherwise numbers outside the range will produce strange and
    * unexpected colors.
    *

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -54,7 +54,7 @@ import processing.awt.ShimAWT;
  *
  *
  * @webref image
- * @webBrief Datatype for storing images.
+ * @webBrief Datatype for storing images
  * @usage Web &amp; Application
  * @instanceName pimg any object of type PImage
  * @see PApplet#loadImage(String)
@@ -96,7 +96,7 @@ public class PImage implements PConstants, Cloneable {
    *
    *
    * @webref image:pixels
-   * @webBrief Array containing the color of every pixel in the image.
+   * @webBrief Array containing the color of every pixel in the image
    * @usage web_application
    */
   public int[] pixels;
@@ -113,7 +113,7 @@ public class PImage implements PConstants, Cloneable {
    * The width of the image in units of pixels.
    *
    * @webref pimage:field
-   * @webBrief The width of the image in units of pixels.
+   * @webBrief The width of the image in units of pixels
    * @usage web_application
    */
   public int width;
@@ -123,7 +123,7 @@ public class PImage implements PConstants, Cloneable {
    * The height of the image in units of pixels.
    *
    * @webref pimage:field
-   * @webBrief The height of the image in units of pixels.
+   * @webBrief The height of the image in units of pixels
    * @usage web_application
    */
   public int height;
@@ -379,7 +379,7 @@ public class PImage implements PConstants, Cloneable {
    * copy all data into the pixels[] array
    *
    * @webref pimage:pixels
-   * @webBrief Loads the pixel data for the image into its <b>pixels[]</b> array.
+   * @webBrief Loads the pixel data for the image into its <b>pixels[]</b> array
    * @usage web_application
    */
   public void loadPixels() {  // ignore
@@ -408,7 +408,7 @@ public class PImage implements PConstants, Cloneable {
    * future.
    *
    * @webref pimage:pixels
-   * @webBrief Updates the image with the data in its <b>pixels[]</b> array.
+   * @webBrief Updates the image with the data in its <b>pixels[]</b> array
    * @usage web_application
    * @param x x-coordinate of the upper-left corner
    * @param y y-coordinate of the upper-left corner
@@ -474,7 +474,7 @@ public class PImage implements PConstants, Cloneable {
    * method, and call <b>resize()</b> on the PImage that is returned.
    *
    * @webref pimage:method
-   * @webBrief Resize the image to a new width and height.
+   * @webBrief Resize the image to a new width and height
    * @usage web_application
    * @param w the resized image width
    * @param h the resized image height
@@ -551,7 +551,7 @@ public class PImage implements PConstants, Cloneable {
    * pixels[] array directly.
    *
    * @webref image:pixels
-   * @webBrief Reads the color of any pixel or grabs a rectangle of pixels.
+   * @webBrief Reads the color of any pixel or grabs a rectangle of pixels
    * @usage web_application
    * @param x x-coordinate of the pixel
    * @param y y-coordinate of the pixel
@@ -1582,7 +1582,7 @@ public class PImage implements PConstants, Cloneable {
    *
    * @webref color:creating_reading
    * @webBrief Blends two color values together based on the blending mode given as the
-   * <b>MODE</b> parameter.
+   * <b>MODE</b> parameter
    * @usage web_application
    * @param c1 the first color to blend
    * @param c2 the second color to blend
@@ -1674,7 +1674,7 @@ public class PImage implements PConstants, Cloneable {
    *
    *
    * @webref image:pixels
-   * @webBrief Copies a pixel or rectangle of pixels using different blending modes.
+   * @webBrief Copies a pixel or rectangle of pixels using different blending modes
    * @param src an image variable referring to the source image
    * @param sx X coordinate of the source's upper left corner
    * @param sy Y coordinate of the source's upper left corner
@@ -3289,7 +3289,7 @@ int testFunction(int dst, int src) {
    * file with no error.
    *
    * @webref pimage:method
-   * @webBrief Saves the image to a TIFF, TARGA, PNG, or JPEG file.
+   * @webBrief Saves the image to a TIFF, TARGA, PNG, or JPEG file
    * @usage application
    * @param filename a sequence of letters and numbers
    */

--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -83,7 +83,7 @@ public class PImage implements PConstants, Cloneable {
 
   /**
    *
-   * The pixels[] array contains the values for all the pixels in the image. These
+   * The <b>pixels[]</b> array contains the values for all the pixels in the image. These
    * values are of the color datatype. This array is the size of the image,
    * meaning if the image is 100 x 100 pixels, there will be 10,000 values and if
    * the window is 200 x 300 pixels, there will be 60,000 values. <br />
@@ -464,12 +464,12 @@ public class PImage implements PConstants, Cloneable {
    * Resize the image to a new width and height. To make the image scale
    * proportionally, use 0 as the value for the <b>wide</b> or <b>high</b>
    * parameter. For instance, to make the width of an image 150 pixels, and
-   * change the height using the same proportion, use resize(150, 0).<br />
+   * change the height using the same proportion, use <b>resize(150, 0)</b>.<br />
    * <br />
-   * Even though a PGraphics is technically a PImage, it is not possible to
-   * rescale the image data found in a PGraphics. (It's simply not possible
+   * Even though a PGraphics is technically a <b>PImage</b>, it is not possible to
+   * rescale the image data found in a <b>PGraphics</b>. (It's simply not possible
    * to do this consistently across renderers: technically infeasible with
-   * P3D, or what would it even do with PDF?) If you want to resize PGraphics
+   * P3D, or what would it even do with PDF?) If you want to resize <b>PGraphics</b>
    * content, first get a copy of its image data using the <b>get()</b>
    * method, and call <b>resize()</b> on the PImage that is returned.
    *
@@ -1631,16 +1631,16 @@ public class PImage implements PConstants, Cloneable {
    * of the following modes to blend the colors of source pixels (A) with the
    * ones of pixels in the destination image (B):<br />
    * <br />
-   * BLEND - linear interpolation of colours: C = A*factor + B<br />
+   * BLEND - linear interpolation of colours: <b>C = A*factor + B</b><br />
    * <br />
-   * ADD - additive blending with white clip: C = min(A*factor + B, 255)<br />
+   * ADD - additive blending with white clip: <b>C = min(A*factor + B, 255)</b><br />
    * <br />
-   * SUBTRACT - subtractive blending with black clip: C = max(B - A*factor,
-   * 0)<br />
+   * SUBTRACT - subtractive blending with black clip: <b>C = max(B - A*factor,
+   * 0)</b><br />
    * <br />
-   * DARKEST - only the darkest colour succeeds: C = min(A*factor, B)<br />
+   * DARKEST - only the darkest colour succeeds: <b>C = min(A*factor, B)</b><br />
    * <br />
-   * LIGHTEST - only the lightest colour succeeds: C = max(A*factor, B)<br />
+   * LIGHTEST - only the lightest colour succeeds: <b>C = max(A*factor, B)</b><br />
    * <br />
    * DIFFERENCE - subtract colors from underlying image.<br />
    * <br />

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -145,7 +145,7 @@ public class PShape implements PConstants {
 
   /**
    *
-   * The width of the PShape document.
+   * The width of the <b>PShape</b> document.
    *
    * @webref pshape:field
    * @usage web_application
@@ -155,7 +155,7 @@ public class PShape implements PConstants {
   public float width;
   /**
    *
-   * The height of the PShape document.
+   * The height of the <b>PShape</b> document.
    *
    * @webref pshape:field
    * @usage web_application
@@ -2005,7 +2005,7 @@ public class PShape implements PConstants {
   }
 
   /**
-   * Returns the number of children within the PShape.
+   * Returns the number of children within the <b>PShape</b>.
    * 
    * @webref
    * @webBrief Returns the number of children
@@ -2037,7 +2037,7 @@ public class PShape implements PConstants {
    *
    * @webref pshape:method
    * @usage web_application
-   * @webBrief Returns a child element of a shape as a PShape object
+   * @webBrief Returns a child element of a shape as a <b>PShape</b> object
    * @param index the layer position of the shape to get
    * @see PShape#addChild(PShape)
    */
@@ -2256,7 +2256,7 @@ public class PShape implements PConstants {
 
   /**
    * The <b>getVertexCount()</b> method returns the number of vertices that 
-   * make up a PShape. In the above example, the value 4 is returned by the 
+   * make up a <b>PShape</b>. In the above example, the value 4 is returned by the 
    * <b>getVertexCount()</b> method because 4 vertices are defined in 
    * <b>setup()</b>.
    * 
@@ -2274,7 +2274,7 @@ public class PShape implements PConstants {
 
 
   /**
-   * The <b>getVertex()</b> method returns a PVector with the coordinates of 
+   * The <b>getVertex()</b> method returns a <b>PVector</b> with the coordinates of 
    * the vertex point located at the position defined by the <b>index</b> 
    * parameter. This method works when shapes are created as shown in the 
    * example above, but won't work properly when a shape is defined explicitly 
@@ -3309,7 +3309,7 @@ public class PShape implements PConstants {
 /**
    *
    * Replaces the current matrix of a shape with the identity matrix. The
-   * equivalent function in OpenGL is glLoadIdentity().
+   * equivalent function in OpenGL is <b>glLoadIdentity()</b>.
    *
    * @webref pshape:method
    * @webBrief Replaces the current matrix of a shape with the identity matrix

--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -87,7 +87,7 @@ import java.util.Base64;
  * </p>
  *
  * @webref shape
- * @webBrief Datatype for storing shapes.
+ * @webBrief Datatype for storing shapes
  * @usage Web &amp; Application
  * @see PApplet#loadShape(String)
  * @see PApplet#createShape()
@@ -400,7 +400,7 @@ public class PShape implements PConstants {
 
   /**
    *
-   * Returns a boolean value "true" if the image is set to be visible, "false" if
+   * Returns a boolean value <b>true</b> if the image is set to be visible, <b>false</b> if
    * not. This value can be modified with the <b>setVisible()</b> method.<br />
    * <br />
    * The default visibility of a shape is usually controlled by whatever program
@@ -409,8 +409,8 @@ public class PShape implements PConstants {
    *
    * @webref pshape:method
    * @usage web_application
-   * @webBrief Returns a boolean value "true" if the image is set to be visible,
-   *           "false" if not
+   * @webBrief Returns a boolean value <b>true</b> if the image is set to be visible,
+   *           <b>false</b> if not
    * @see PShape#setVisible(boolean)
    */
   public boolean isVisible() {
@@ -781,7 +781,7 @@ public class PShape implements PConstants {
    * function. It's always and only used with <b>createShape()</b>. 
    * 
    * @webref pshape:method
-   * @webBrief Starts the creation of a new PShape
+   * @webBrief Starts the creation of a new <b>PShape</b>
    * @see PApplet#endShape()
    */
   public void beginShape() {
@@ -799,7 +799,7 @@ public class PShape implements PConstants {
    * function. It's always and only used with <b>createShape()</b>. 
    *
    * @webref pshape:method
-   * @webBrief Finishes the creation of a new PShape
+   * @webBrief Finishes the creation of a new <b>PShape</b>
    * @see PApplet#beginShape()
    */
   public void endShape() {

--- a/core/src/processing/core/PVector.java
+++ b/core/src/processing/core/PVector.java
@@ -138,7 +138,7 @@ public class PVector implements Serializable {
   /**
    *
    * Sets the x, y, and z component of the vector using two or three separate
-   * variables, the data from a PVector, or the values from a float array.
+   * variables, the data from a <b>PVector</b>, or the values from a float array.
    *
    *
    * @webref pvector:method
@@ -345,7 +345,7 @@ public class PVector implements Serializable {
 
   /**
    *
-   * Copies the components of the vector and returns the result as a PVector. 
+   * Copies the components of the vector and returns the result as a <b>PVector</b>. 
    *
    *
    * @webref pvector:method
@@ -420,7 +420,7 @@ public class PVector implements Serializable {
    *
    * Adds x, y, and z components to a vector, adds one vector to another, or adds
    * two independent vectors together. The version of the method that adds two
-   * vectors together is a static method and returns a new PVector, the others act
+   * vectors together is a static method and returns a new <b>PVector</b>, the others act
    * directly on the vector itself. See the examples for more context.
    *
    *
@@ -488,7 +488,7 @@ public class PVector implements Serializable {
    *
    * Subtracts x, y, and z components from a vector, subtracts one vector from
    * another, or subtracts two independent vectors. The version of the method that
-   * substracts two vectors is a static method and returns a PVector, the others
+   * substracts two vectors is a static method and returns a <b>PVector</b>, the others
    * act directly on the vector. See the examples for more context. In all cases,
    * the second vector (v2) is subtracted from the first (v1), resulting in v1-v2.
    *
@@ -557,8 +557,8 @@ public class PVector implements Serializable {
    *
    * Multiplies a vector by a scalar. The version of the method that uses a float
    * acts directly on the vector upon which it is called (as in the first example
-   * above). The versions that receive both a PVector and a float as arguments are
-   * static methods, and each returns a new PVector that is the result of the
+   * above). The versions that receive both a <b>PVector</b> and a float as arguments are
+   * static methods, and each returns a new <b>PVector</b> that is the result of the
    * multiplication operation. Both examples above produce the same visual output.
    *
    *
@@ -601,8 +601,8 @@ public class PVector implements Serializable {
    *
    * Divides a vector by a scalar. The version of the method that uses a float
    * acts directly on the vector upon which it is called (as in the first example
-   * above). The version that receives both a PVector and a float as arguments is
-   * a static methods, and returns a new PVector that is the result of the
+   * above). The version that receives both a <b>PVector</b> and a <b>float</b> as arguments is
+   * a static methods, and returns a new <b>PVector</b> that is the result of the
    * division operation. Both examples above produce the same visual output.
    *
    * @webref pvector:method
@@ -898,7 +898,7 @@ public class PVector implements Serializable {
    * static version is used by referencing the PVector class directly. (See the
    * middle example above.) The non-static versions, <b>lerp(v, amt)</b> and
    * <b>lerp(x, y, z, amt)</b>, do not create a new PVector, but transform the
-   * values of the PVector on which they are called. These non-static versions
+   * values of the <b>PVector</b> on which they are called. These non-static versions
    * perform the same operation, but the former takes another vector as input,
    * while the latter takes three float values. (See the top and bottom examples
    * above, respectively.)

--- a/core/src/processing/core/PVector.java
+++ b/core/src/processing/core/PVector.java
@@ -62,7 +62,7 @@ import java.io.Serializable;
  * <a href="http://www.shiffman.net">Dan Shiffman</a>.
  *
  * @webref math
- * @webBrief A class to describe a two or three dimensional vector.
+ * @webBrief A class to describe a two or three dimensional vector
  */
 public class PVector implements Serializable {
   /**
@@ -205,7 +205,7 @@ public class PVector implements Serializable {
    * @webref pvector:method
    * @usage web_application
    * @return the random PVector
-   * @webBrief Make a new 2D unit vector with a random direction.
+   * @webBrief Make a new 2D unit vector with a random direction
    * @see PVector#random3D()
    */
   static public PVector random2D() {
@@ -255,7 +255,7 @@ public class PVector implements Serializable {
    * @webref pvector:method
    * @usage web_application
    * @return the random PVector
-   * @webBrief Make a new 3D unit vector with a random direction.
+   * @webBrief Make a new 3D unit vector with a random direction
    * @see PVector#random2D()
    */
   static public PVector random3D() {

--- a/core/src/processing/data/FloatDict.java
+++ b/core/src/processing/data/FloatDict.java
@@ -9,11 +9,11 @@ import processing.core.PApplet;
 
 
 /**
- * A simple class to use a String as a lookup for an float value. String "keys"
+ * A simple class to use a <b>String</b> as a lookup for a float value. String "keys"
  * are associated with floating-point values.
  *
  * @webref data:composite
- * @webBrief A simple table class to use a String as a lookup for an float
+ * @webBrief A simple table class to use a <b>String</b> as a lookup for a float
  *           value.
  * @see IntDict
  * @see StringDict
@@ -415,7 +415,7 @@ public class FloatDict {
 
 
   /**
-   * Add to a value. If the key does not exist, an new pair is initialized with
+   * Add to a value. If the key does not exist, a new pair is initialized with
    * the value supplied.
    * 
    * @webref floatdict:method

--- a/core/src/processing/data/FloatDict.java
+++ b/core/src/processing/data/FloatDict.java
@@ -14,7 +14,7 @@ import processing.core.PApplet;
  *
  * @webref data:composite
  * @webBrief A simple table class to use a <b>String</b> as a lookup for a float
- *           value.
+ *           value
  * @see IntDict
  * @see StringDict
  */

--- a/core/src/processing/data/FloatList.java
+++ b/core/src/processing/data/FloatList.java
@@ -18,7 +18,7 @@ import processing.core.PApplet;
  * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
- * @webBrief Helper class for a list of floats.
+ * @webBrief Helper class for a list of floats
  * @see IntList
  * @see StringList
  */
@@ -678,7 +678,7 @@ public class FloatList implements Iterable<Float> {
    * <b>reverse()</b>, but is more efficient than running each separately.
    *
    * @webref floatlist:method
-   * @webBrief A sort in reverse.
+   * @webBrief A sort in reverse
    */
   public void sortReverse() {
     new Sort() {

--- a/core/src/processing/data/FloatList.java
+++ b/core/src/processing/data/FloatList.java
@@ -11,11 +11,11 @@ import processing.core.PApplet;
 
 /**
  * Helper class for a list of floats. Lists are designed to have some of the
- * features of ArrayLists, but to maintain the simplicity and efficiency of
+ * features of <b>ArrayLists</b>, but to maintain the simplicity and efficiency of
  * working with arrays.
  *
- * Functions like sort() and shuffle() always act on the list itself. To get
- * a sorted copy, use list.copy().sort().
+ * Functions like <b>sort()</b> and <b>shuffle()</b> always act on the list itself. To get
+ * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
  * @webBrief Helper class for a list of floats.

--- a/core/src/processing/data/IntDict.java
+++ b/core/src/processing/data/IntDict.java
@@ -13,7 +13,7 @@ import processing.core.PApplet;
  * associated with integer values.
  *
  * @webref data:composite
- * @webBrief A simple class to use a <b>String</b> as a lookup for an int value.
+ * @webBrief A simple class to use a <b>String</b> as a lookup for an int value
  * @see FloatDict
  * @see StringDict
  */

--- a/core/src/processing/data/IntDict.java
+++ b/core/src/processing/data/IntDict.java
@@ -9,11 +9,11 @@ import processing.core.PApplet;
 
 
 /**
- * A simple class to use a String as a lookup for an int value. String "keys" are 
+ * A simple class to use a <b>String</b> as a lookup for an int value. String "keys" are 
  * associated with integer values.
  *
  * @webref data:composite
- * @webBrief A simple class to use a String as a lookup for an int value.
+ * @webBrief A simple class to use a <b>String</b> as a lookup for an int value.
  * @see FloatDict
  * @see StringDict
  */

--- a/core/src/processing/data/IntList.java
+++ b/core/src/processing/data/IntList.java
@@ -23,7 +23,7 @@ import processing.core.PApplet;
  * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
- * @webBrief Helper class for a list of ints.
+ * @webBrief Helper class for a list of ints
  * @see FloatList
  * @see StringList
  */

--- a/core/src/processing/data/IntList.java
+++ b/core/src/processing/data/IntList.java
@@ -16,11 +16,11 @@ import processing.core.PApplet;
 
 /**
  * Helper class for a list of ints. Lists are designed to have some of the
- * features of ArrayLists, but to maintain the simplicity and efficiency of
+ * features of <b>ArrayLists</b>, but to maintain the simplicity and efficiency of
  * working with arrays.
  *
- * Functions like sort() and shuffle() always act on the list itself. To get
- * a sorted copy, use list.copy().sort().
+ * Functions like <b>sort()</b> and <b>shuffle()</b> always act on the list itself. To get
+ * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
  * @webBrief Helper class for a list of ints.

--- a/core/src/processing/data/JSONArray.java
+++ b/core/src/processing/data/JSONArray.java
@@ -279,7 +279,7 @@ public class JSONArray {
 
 
   /**
-   * Gets the String value associated with the specified index.
+   * Gets the <b>String</b> value associated with the specified index.
    *
    * @webref jsonarray:method
    * @webBrief Gets the String value associated with an index
@@ -562,11 +562,11 @@ public class JSONArray {
 
 
   /**
-   * Returns the entire <b>JSONArray</b> as an array of Strings.  
-   * (All values in the array must be of the String type.)
+   * Returns the entire <b>JSONArray</b> as an array of <b>Strings</b>.  
+   * (All values in the array must be of the <b>String</b> type.)
    *
    * @webref jsonarray:method
-   * @webBrief Returns the entire <b>JSONArray</b> as an array of Strings
+   * @webBrief Returns the entire <b>JSONArray</b> as an array of <b>Strings</b>
    * @see JSONArray#getIntArray()
    */
   public String[] getStringArray() {
@@ -579,11 +579,11 @@ public class JSONArray {
 
 
   /**
-   * Returns the entire <b>JSONArray</b> as an array of ints.  
+   * Returns the entire <b>JSONArray</b> as an array of <b>ints</b>.  
    * (All values in the array must be of the int type.)
    *
    * @webref jsonarray:method
-   * @webBrief Returns the entire <b>JSONArray</b> as an array of ints
+   * @webBrief Returns the entire <b>JSONArray</b> as an array of <b>ints</b>
    * @see JSONArray#getStringArray()
    */
   public int[] getIntArray() {
@@ -702,8 +702,8 @@ public class JSONArray {
 
   /**
    * Appends a new value to the <b>JSONArray</b>, increasing the array's length 
-   * by one. New values may be of the following types: int, float, String, 
-   * boolean, <b>JSONObject</b>, or <b>JSONArray</b>.
+   * by one. New values may be of the following types: <b>int</b>, <b>float</b>, <b>String</b>, 
+   * <b>boolean</b>, <b>JSONObject</b>, or <b>JSONArray</b>.
    *
    * @webref jsonarray:method
    * @webBrief Appends a value, increasing the array's length by one
@@ -1080,7 +1080,7 @@ public class JSONArray {
 
   /**
    * Removes the element from a <b>JSONArray</b> in the specified index position. 
-   * Returns either the value associated with the given index, or null, if there 
+   * Returns either the value associated with the given index, or <b>null</b>, if there 
    * is no value.
    *
    * @webref jsonarray:method

--- a/core/src/processing/data/JSONArray.java
+++ b/core/src/processing/data/JSONArray.java
@@ -96,7 +96,7 @@ import processing.core.PApplet;
  * @author JSON.org
  * @version 2012-11-13
  * @webref data:composite
- * @webBrief A JSONArray is an ordered sequence of values.
+ * @webBrief A JSONArray is an ordered sequence of values
  * @see JSONObject
  * @see PApplet#loadJSONObject(String)
  * @see PApplet#loadJSONArray(String)
@@ -317,7 +317,7 @@ public class JSONArray {
    * Gets the int value associated with the specified index.
    *
    * @webref jsonarray:method
-   * @webBrief Gets the int value associated with the specified index.
+   * @webBrief Gets the int value associated with the specified index
    * @param index must be between 0 and length() - 1
    * @return The value.
    * @throws RuntimeException If the key is not found or if the value is not a number.
@@ -395,7 +395,7 @@ public class JSONArray {
    * Gets the float value associated with the specified index.
    *
    * @webref jsonarray:method
-   * @webBrief Gets the float value associated with the specified index.
+   * @webBrief Gets the float value associated with the specified index
    * @param index must be between 0 and length() - 1
    * @see JSONArray#getInt(int)
    * @see JSONArray#getString(int)
@@ -457,7 +457,7 @@ public class JSONArray {
    * Gets the boolean value associated with the specified index.
    *
    * @webref jsonarray:method
-   * @webBrief Gets the boolean value associated with the specified index.
+   * @webBrief Gets the boolean value associated with the specified index
    * @param index must be between 0 and length() - 1
    * @return      The truth.
    * @throws RuntimeException If there is no value for the index or if the
@@ -503,7 +503,7 @@ public class JSONArray {
    * Retrieves the <b>JSONArray</b> with the associated index value.
    *
    * @webref jsonobject:method
-   * @webBrief Retrieves the <b>JSONArray</b> with the associated index value.
+   * @webBrief Retrieves the <b>JSONArray</b> with the associated index value
    * @param index must be between 0 and length() - 1
    * @return A JSONArray value.
    * @throws RuntimeException If there is no value for the index. or if the
@@ -534,7 +534,7 @@ public class JSONArray {
    * Retrieves the <b>JSONObject</b> with the associated index value.
    *
    * @webref jsonobject:method
-   * @webBrief Retrieves the <b>JSONObject</b> with the associated index value.
+   * @webBrief Retrieves the <b>JSONObject</b> with the associated index value
    * @param index the index value of the object to get
    * @return A JSONObject value.
    * @throws RuntimeException If there is no value for the index or if the
@@ -862,7 +862,7 @@ public class JSONArray {
    * necessary to pad it out.
    *
    * @webref jsonarray:method
-   * @webBrief Inserts a new value into the <b>JSONArray</b> at the specified index position. 
+   * @webBrief Inserts a new value into the <b>JSONArray</b> at the specified index position
    * @param index an index value
    * @param value the value to assign
    * @return this.

--- a/core/src/processing/data/JSONObject.java
+++ b/core/src/processing/data/JSONObject.java
@@ -52,7 +52,7 @@ import processing.core.PApplet;
 
 /**
  * A <b>JSONObject</b> stores JSON data with multiple name/value pairs. Values
- * can be numeric, Strings, booleans, other <b>JSONObject</b>s or
+ * can be numeric, <b>Strings</b>, <b>booleans</b>, other <b>JSONObject</b>s or
  * <b>JSONArray</b>s, or null. <b>JSONObject</b> and <b>JSONArray</b> objects
  * are quite similar and share most of the same methods; the primary difference
  * is that the latter stores an array of JSON objects, while the former
@@ -567,7 +567,7 @@ public class JSONObject {
 
 
   /**
-   * Gets the String value associated with the specified key.
+   * Gets the <b>String</b> value associated with the specified key.
    *
    * @webref jsonobject:method
    * @webBrief Gets the String value associated with the specified key

--- a/core/src/processing/data/JSONObject.java
+++ b/core/src/processing/data/JSONObject.java
@@ -116,7 +116,7 @@ import processing.core.PApplet;
  * @author JSON.org
  * @version 2012-12-01
  * @webref data:composite
- * @webBrief A JSONObject is an unordered collection of name/value pairs.
+ * @webBrief A <b>JSONObject</b> is an unordered collection of name/value pairs
  * @see JSONArray
  * @see PApplet#loadJSONObject(String)
  * @see PApplet#loadJSONArray(String)
@@ -570,7 +570,7 @@ public class JSONObject {
    * Gets the <b>String</b> value associated with the specified key.
    *
    * @webref jsonobject:method
-   * @webBrief Gets the String value associated with the specified key
+   * @webBrief Gets the <b>String</b> value associated with the specified key
    * @param key a key string
    * @return A string which is the value.
    * @throws RuntimeException if there is no string value for the key.
@@ -606,10 +606,10 @@ public class JSONObject {
 
 
   /**
-   * Gets the int value associated with the specified key.
+   * Gets the <b>int</b> value associated with the specified key.
    *
    * @webref jsonobject:method
-   * @webBrief Gets the int value associated with the specified key
+   * @webBrief Gets the <b>int</b> value associated with the specified key
    * @param key A key string.
    * @return The integer value.
    * @throws RuntimeException if the key is not found or if the value cannot
@@ -691,10 +691,10 @@ public class JSONObject {
 
 
   /**
-   * Gets the float value associated with the specified key
+   * Gets the <b>float</b> value associated with the specified key
    *
    * @webref jsonobject:method
-   * @webBrief Gets the float value associated with a key
+   * @webBrief Gets the <b>float</b> value associated with a key
    * @param key a key string
    * @see JSONObject#getInt(String)
    * @see JSONObject#getString(String)
@@ -753,10 +753,10 @@ public class JSONObject {
 
 
   /**
-   * Gets the boolean value associated with the specified key.
+   * Gets the <b>boolean</b> value associated with the specified key.
    *
    * @webref jsonobject:method
-   * @webBrief Gets the boolean value associated with the specified key
+   * @webBrief Gets the <b>boolean</b> value associated with the specified key
    * @param key a key string
    * @return The truth.
    * @throws RuntimeException if the value is not a Boolean or the String "true" or "false".
@@ -933,7 +933,7 @@ public class JSONObject {
    *
    * @webref
    * @webBrief Determines if the value associated with the key is <b>null</b>, that is has 
-   * no defined value (<b>false</b>) or if it has a value (<b>true</b>).
+   * no defined value (<b>false</b>) or if it has a value (<b>true</b>)
    * @param key   A key string.
    * @return      true if there is no value associated with the key or if
    *  the value is the JSONObject.NULL object.
@@ -1227,7 +1227,7 @@ public class JSONObject {
    * the specified key already exists, assigns a new value.
    * 
    * @webref jsonobject:method
-   * @webBrief Put a key/float pair in the JSONObject
+   * @webBrief Put a key/float pair in the <b>JSONObject</b>
    * @param key a key string
    * @param value the value to assign
    * @throws RuntimeException If the key is null or if the number is NaN or infinite.
@@ -1260,7 +1260,7 @@ public class JSONObject {
    * with the specified key already exists, assigns a new value.
    *
    * @webref jsonobject:method
-   * @webBrief Put a key/boolean pair in the JSONObject
+   * @webBrief Put a key/boolean pair in the <b>JSONObject</b>
    * @param key a key string
    * @param value the value to assign
    * @return this.

--- a/core/src/processing/data/LongList.java
+++ b/core/src/processing/data/LongList.java
@@ -710,7 +710,7 @@ public class LongList implements Iterable<Long> {
 
   /**
    * Randomize the order of the list elements. Note that this does not
-   * obey the randomSeed() function in PApplet.
+   * obey the <b>randomSeed()</b> function in PApplet.
    *
    * @webref intlist:method
    * @webBrief Randomize the order of the list elements

--- a/core/src/processing/data/StringDict.java
+++ b/core/src/processing/data/StringDict.java
@@ -9,8 +9,8 @@ import processing.core.PApplet;
 
 
 /**
- * A simple class to use a String as a lookup for an String value. String "keys" 
- * are associated with String values.
+ * A simple class to use a <b>String</b> as a lookup for a <b>String</b> value. String "keys" 
+ * are associated with <b>String</b> values.
  *
  * @webref data:composite
  * @webBrief A simple class to use a String as a lookup for an String value

--- a/core/src/processing/data/StringDict.java
+++ b/core/src/processing/data/StringDict.java
@@ -13,7 +13,7 @@ import processing.core.PApplet;
  * are associated with <b>String</b> values.
  *
  * @webref data:composite
- * @webBrief A simple class to use a String as a lookup for an String value
+ * @webBrief A simple class to use a <b>String</b> as a lookup for an <b>String</b> value
  * @see IntDict
  * @see FloatDict
  */

--- a/core/src/processing/data/StringList.java
+++ b/core/src/processing/data/StringList.java
@@ -17,7 +17,7 @@ import processing.core.PApplet;
  * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
- * @webBrief Helper class for a list of Strings.
+ * @webBrief Helper class for a list of Strings
  * @see IntList
  * @see FloatList
  */

--- a/core/src/processing/data/StringList.java
+++ b/core/src/processing/data/StringList.java
@@ -9,12 +9,12 @@ import java.util.Random;
 import processing.core.PApplet;
 
 /**
- * Helper class for a list of Strings. Lists are designed to have some of the
- * features of ArrayLists, but to maintain the simplicity and efficiency of
+ * Helper class for a list of <b>Strings</b>. Lists are designed to have some of the
+ * features of <b>ArrayLists</b>, but to maintain the simplicity and efficiency of
  * working with arrays.
  *
- * Functions like sort() and shuffle() always act on the list itself. To get
- * a sorted copy, use list.copy().sort().
+ * Functions like <b>sort()</b> and <b>shuffle()</b> always act on the list itself. To get
+ * a sorted copy, use <b>list.copy().sort()</b>.
  *
  * @webref data:composite
  * @webBrief Helper class for a list of Strings.
@@ -149,7 +149,7 @@ public class StringList implements Iterable<String> {
   /**
    * Set the entry at a particular index. If the index is past the length of
    * the list, it'll expand the list to accommodate, and fill the intermediate
-   * entries with "null".
+   * entries with <b>null</b>.
    *
    * @webref stringlist:method
    * @webBrief Set an entry at a particular index

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -76,7 +76,7 @@ import processing.core.PConstants;
  *
  * @webref data:composite
  * @webBrief Generic class for handling tabular data, typically from a CSV, TSV,
- *           or other sort of spreadsheet file.
+ *           or other sort of spreadsheet file
  * @see PApplet#loadTable(String)
  * @see PApplet#saveTable(Table, String)
  * @see TableRow
@@ -2285,10 +2285,10 @@ public class Table {
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
   /**
-   * Returns the total number of rows in a table.
+   * Returns the total number of rows in a <b>Table</b>.
    *
    * @webref table:method
-   * @webBrief Returns the total number of rows in a table
+   * @webBrief Returns the total number of rows in a <b>Table</b>
    * @see Table#getColumnCount()
    */
   public int getRowCount() {

--- a/core/src/processing/data/Table.java
+++ b/core/src/processing/data/Table.java
@@ -1806,9 +1806,9 @@ public class Table {
    * Use <b>addColumn()</b> to add a new column to a <b>Table</b> object.
    * Typically, you will want to specify a title, so the column may be easily
    * referenced later by name. (If no title is specified, the new column's title
-   * will be null.) A column type may also be specified, in which case all values
-   * stored in this column must be of the same type (e.g., Table.INT or
-   * Table.FLOAT). If no type is specified, the default type of STRING is used.
+   * will be <b>null</b>.) A column type may also be specified, in which case all values
+   * stored in this column must be of the same type (e.g., <b>Table.INT</b> or
+   * <b>Table.FLOAT</b>). If no type is specified, the default type of <b>STRING</b> is used.
    *
    * @webref table:method
    * @webBrief Adds a new column to a table
@@ -1886,7 +1886,7 @@ public class Table {
   /**
    * Use <b>removeColumn()</b> to remove an existing column from a <b>Table</b>
    * object. The column to be removed may be identified by either its title (a
-   * String) or its index value (an int). <b>removeColumn(0)</b> would remove the
+   * <b>String</b>) or its index value (an <b>int</b>). <b>removeColumn(0)</b> would remove the
    * first column, <b>removeColumn(1)</b> would remove the second column, and so
    * on.
    *
@@ -3609,7 +3609,7 @@ public class Table {
   }
 
   /**
-   * Retrieves all values in the specified column, and returns them as a String
+   * Retrieves all values in the specified column, and returns them as a <b>String</b>
    * array.  The column may be specified by either its ID or title.
    *
    * @webref table:method

--- a/core/src/processing/data/TableRow.java
+++ b/core/src/processing/data/TableRow.java
@@ -99,7 +99,7 @@ public interface TableRow {
   public double getDouble(String columnName);
 
   /**
-   * Stores a String value in the <b>TableRow</b>'s specified column. The column 
+   * Stores a <b>String</b> value in the <b>TableRow</b>'s specified column. The column 
    * may be specified by either its ID or title.
    *
    * @webref tablerow:method
@@ -116,7 +116,7 @@ public interface TableRow {
   public void setString(String columnName, String value);
 
   /**
-   * Stores an integer value in the <b>TableRow</b>'s specified column. The column 
+   * Stores an <b>integer</b> value in the <b>TableRow</b>'s specified column. The column 
    * may be specified by either its ID or title.
    * 
    * @webref tablerow:method
@@ -148,7 +148,7 @@ public interface TableRow {
   public void setLong(String columnName, long value);
 
   /**
-   * Stores a float value in the <b>TableRow</b>'s specified column. The column 
+   * Stores a <b>float</b> value in the <b>TableRow</b>'s specified column. The column 
    * may be specified by either its ID or title.
    *
    * @webref tablerow:method

--- a/core/src/processing/data/TableRow.java
+++ b/core/src/processing/data/TableRow.java
@@ -4,13 +4,13 @@ import java.io.PrintWriter;
 
 /**
  * A <b>TableRow</b> object represents a single row of data values, 
- * stored in columns, from a table.<br />
+ * stored in columns, from a <b>Table</b>.<br />
  * <br />
  * Additional <b>TableRow</b> methods are documented in the 
  * <a href="http://processing.github.io/processing-javadocs/core/">Processing Data Javadoc</a>.
  *
  * @webref data:composite
- * @webBrief represents a single row of data values, stored in columns, from a table.
+ * @webBrief Represents a single row of data values, stored in columns, from a <b>Table<b>
  * @see Table
  * @see Table#addRow()
  * @see Table#removeRow(int)
@@ -25,7 +25,7 @@ public interface TableRow {
    * The column may be specified by either its ID or title.
    *
    * @webref tablerow:method
-   * @webBrief Get an String value from the specified column
+   * @webBrief Get a <b>String</b> value from the specified column
    * @param column ID number of the column to reference
    * @see TableRow#getInt(int)
    * @see TableRow#getFloat(int)
@@ -42,7 +42,7 @@ public interface TableRow {
    * The column may be specified by either its ID or title.
    *
    * @webref tablerow:method
-   * @webBrief Get an integer value from the specified column
+   * @webBrief Get an <b>integer</b> value from the specified column
    * @param column ID number of the column to reference
    * @see TableRow#getFloat(int)
    * @see TableRow#getString(int)
@@ -55,7 +55,7 @@ public interface TableRow {
   public int getInt(String columnName);
 
   /**
-   * @webBrief Get a long value from the specified column
+   * @webBrief Get a <b>long</b> value from the specified column
    * @param column ID number of the column to reference
    * @see TableRow#getFloat(int)
    * @see TableRow#getString(int)
@@ -73,7 +73,7 @@ public interface TableRow {
    * The column may be specified by either its ID or title.
    *
    * @webref tablerow:method
-   * @webBrief Get a float value from the specified column
+   * @webBrief Get a <b>float</b> value from the specified column
    * @param column ID number of the column to reference
    * @see TableRow#getInt(int)
    * @see TableRow#getString(int)
@@ -86,7 +86,7 @@ public interface TableRow {
   public float getFloat(String columnName);
   
   /**
-   * @webBrief Get a double value from the specified column
+   * @webBrief Get a <b>double</b> value from the specified column
    * @param column ID number of the column to reference
    * @see TableRow#getInt(int)
    * @see TableRow#getString(int)
@@ -103,7 +103,7 @@ public interface TableRow {
    * may be specified by either its ID or title.
    *
    * @webref tablerow:method
-   * @webBrief Store a String value in the specified column
+   * @webBrief Store a <b>String</b> value in the specified column
    * @param column ID number of the target column
    * @param value value to assign
    * @see TableRow#setInt(int, int)
@@ -120,7 +120,7 @@ public interface TableRow {
    * may be specified by either its ID or title.
    * 
    * @webref tablerow:method
-   * @webBrief Store an integer value in the specified column
+   * @webBrief Store an <b>integer</b> value in the specified column
    * @param column ID number of the target column
    * @param value value to assign
    * @see TableRow#setFloat(int, float)
@@ -134,7 +134,7 @@ public interface TableRow {
   public void setInt(String columnName, int value);
   
   /**
-   * @webBrief Store a long value in the specified column
+   * @webBrief Store a <b>long</b> value in the specified column
    * @param column ID number of the target column
    * @param value value to assign
    * @see TableRow#setFloat(int, float)
@@ -152,7 +152,7 @@ public interface TableRow {
    * may be specified by either its ID or title.
    *
    * @webref tablerow:method
-   * @webBrief Store a float value in the specified column
+   * @webBrief Store a <b>float</b> value in the specified column
    * @param column ID number of the target column
    * @param value value to assign
    * @see TableRow#setInt(int, int)
@@ -166,7 +166,7 @@ public interface TableRow {
   public void setFloat(String columnName, float value);
 
   /**
-   * @webBrief Store a double value in the specified column
+   * @webBrief Store a <b>double</b> value in the specified column
    * @param column ID number of the target column
    * @param value value to assign
    * @see TableRow#setFloat(int, float)
@@ -183,13 +183,13 @@ public interface TableRow {
    * Returns the number of columns in a <b>TableRow</b>.
    *
    * @webref tablerow:method
-   * @webBrief Get the column count.
+   * @webBrief Get the column count
    * @return count of all columns
    */
   public int getColumnCount();
   
   /**
-   * @webBrief Get the column type.
+   * @webBrief Get the column type
    * @param columnName title of the target column
    * @return type of the column
    */

--- a/core/src/processing/data/XML.java
+++ b/core/src/processing/data/XML.java
@@ -41,16 +41,16 @@ import processing.core.PApplet;
 
 
 /**
- * <b>XML</b> is a representation of an XML object, able to parse XML code. Use
+ * <b>XML</b> is a representation of an <b>XML</b> object, able to parse <b>XML</b> code. Use
  * <b>loadXML()</b> to load external XML files and create <b>XML</b>
  * objects.<br />
  * <br />
  * Only files encoded as UTF-8 (or plain ASCII) are parsed properly; the
- * encoding parameter inside XML files is ignored.
+ * encoding parameter inside <b>XML</b> files is ignored.
  *
  * @webref data:composite
  * @webBrief This is the base class used for the Processing XML library,
- *           representing a single node of an XML tree.
+ *           representing a single node of an <b>XML</b> tree.
  * @see PApplet#loadXML(String)
  * @see PApplet#parseXML(String)
  * @see PApplet#saveXML(XML, String)
@@ -253,10 +253,10 @@ public class XML implements Serializable {
 
 
   /**
-   * Converts String content to an XML object
+   * Converts <b>String</b> content to an <b>XML</b> object
    *
    * @webref xml:method
-   * @webBrief Converts String content to an XML object
+   * @webBrief Converts <b>String</b> content to an <b>XML</b> object
    * @param data the content to be parsed as XML
    * @return an XML object, or null
    * @throws SAXException
@@ -305,7 +305,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Gets a copy of the element's parent.  Returns the parent as another XML object.
+   * Gets a copy of the element's parent.  Returns the parent as another <b>XML</b> object.
    *
    * @webref xml:method
    * @webBrief Gets a copy of the element's parent
@@ -323,7 +323,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Gets the element's full name, which is returned as a String.
+   * Gets the element's full name, which is returned as a <b>String</b>.
    *
    * @webref xml:method
    * @webBrief Gets the element's full name
@@ -335,7 +335,7 @@ public class XML implements Serializable {
   }
 
   /**
-   * Sets the element's name, which is specified as a String.
+   * Sets the element's name, which is specified as a <b>String</b>.
    *
    * @webref xml:method
    * @webBrief Sets the element's name
@@ -388,7 +388,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Checks whether or not the element has any children, and returns the result as a boolean.
+   * Checks whether or not the element has any children, and returns the result as a <b>boolean</b>.
    *
    * @webref xml:method
    * @webBrief Checks whether or not an element has any children
@@ -401,7 +401,7 @@ public class XML implements Serializable {
 
   /**
    * Get the names of all of the element's children, and returns the names as an 
-   * array of Strings. This is the same as looping through and calling getName() 
+   * array of <b>Strings</b>. This is the same as looping through and calling <b>getName()</b> 
    * on each child element individually.
    *
    * @webref xml:method
@@ -427,7 +427,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Returns all of the element's children as an array of XML objects. When 
+   * Returns all of the element's children as an array of <b>XML</b> objects. When 
    * the <b>name</b> parameter is specified, then it will return all children 
    * that match that name or path. The path is a series of elements and 
    * sub-elements, separated by slashes.
@@ -572,10 +572,10 @@ public class XML implements Serializable {
 
   /**
    * Appends a new child to the element. The child can be specified with either a
-   * String, which will be used as the new tag's name, or as a reference to an
-   * existing XML object.<br />
+   * <b>String</b>, which will be used as the new tag's name, or as a reference to an
+   * existing <b>XML</b> object.<br />
    * <br />
-   * A reference to the newly created child is returned as an XML object.
+   * A reference to the newly created child is returned as an <b>XML</b> object.
    *
    * @webref xml:method
    * @webBrief Appends a new child to the element
@@ -695,7 +695,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Counts the specified element's number of attributes, returned as an int.
+   * Counts the specified element's number of attributes, returned as an <b>int</b>.
    *
    * @webref xml:method
    * @webBrief Counts the specified element's number of attributes
@@ -706,7 +706,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Gets all of the specified element's attributes, and returns them as an array of Strings.
+   * Gets all of the specified element's attributes, and returns them as an array of <b>Strings</b>.
    *
    * @webref xml:method
    * @webBrief Returns a list of names of all attributes as an array
@@ -722,7 +722,7 @@ public class XML implements Serializable {
 
   /**
    * Checks whether or not an element has the specified attribute.  The attribute 
-   * must be specified as a String, and a boolean is returned.
+   * must be specified as a <b>String</b>, and a <b>boolean</b> is returned.
    *
    * @webref xml:method
    * @webBrief Checks whether or not an element has the specified attribute
@@ -757,13 +757,13 @@ public class XML implements Serializable {
 
 
   /**
-   * Returns an attribute value of the element as a String. If the <b>defaultValue</b> 
+   * Returns an attribute value of the element as a <b>String</b>. If the <b>defaultValue</b> 
    * parameter is specified and the attribute doesn't exist, then <b>defaultValue</b> 
    * is returned. If no <b>defaultValue</b> is specified and the attribute doesn't 
-   * exist, null is returned.
+   * exist, <b>null</b> is returned.
    *
    * @webref xml:method
-   * @webBrief Gets the content of an attribute as a String
+   * @webBrief Gets the content of an attribute as a <b>String</b>
    */
   public String getString(String name) {
     return getString(name, null);
@@ -783,11 +783,11 @@ public class XML implements Serializable {
 
 
   /**
-   * Sets the content of an element's attribute as a String.  The first String 
+   * Sets the content of an element's attribute as a <b>String</b>.  The first <b>String</b> 
    * specifies the attribute name, while the second specifies the new content.
    *
    * @webref xml:method
-   * @webBrief Sets the content of an attribute as a String
+   * @webBrief Sets the content of an attribute as a <b>String</b>
    */
   public void setString(String name, String value) {
     ((Element) node).setAttribute(name, value);
@@ -795,13 +795,13 @@ public class XML implements Serializable {
 
 
   /**
-   * Returns an attribute value of the element as an int. If the <b>defaultValue</b> 
+   * Returns an attribute value of the element as an <b>int</b>. If the <b>defaultValue</b> 
    * parameter is specified and the attribute doesn't exist, then <b>defaultValue</b> 
    * is returned. If no <b>defaultValue</b> is specified and the attribute doesn't 
    * exist, the value 0 is returned.
    *
    * @webref xml:method
-   * @webBrief Gets the content of an attribute as an int
+   * @webBrief Gets the content of an attribute as an <b>int</b>
    */
   public int getInt(String name) {
     return getInt(name, 0);
@@ -809,11 +809,11 @@ public class XML implements Serializable {
 
 
   /**
-   * Sets the content of an element's attribute as an int.  A String specifies 
+   * Sets the content of an element's attribute as an <b>int</b>.  A <b>String</b> specifies 
    * the attribute name, while the int specifies the new content.
    *
    * @webref xml:method
-   * @webBrief Sets the content of an attribute as an int
+   * @webBrief Sets the content of an attribute as an <b>int</b>
    */
   public void setInt(String name, int value) {
     setString(name, String.valueOf(value));
@@ -834,10 +834,10 @@ public class XML implements Serializable {
 
 
   /**
-   * Sets the content of an element as an int
+   * Sets the content of an element as an <b>int</b>
    *
    * @webref xml:method
-   * @webBrief Sets the content of an element as an int
+   * @webBrief Sets the content of an element as an <b>int</b>
    */
   public void setLong(String name, long value) {
     setString(name, String.valueOf(value));
@@ -864,7 +864,7 @@ public class XML implements Serializable {
    * and the attribute doesn't exist, the value 0.0 is returned.
    *
    * @webref xml:method
-   * @webBrief Gets the content of an attribute as a float
+   * @webBrief Gets the content of an attribute as a <b>float</b>
    */
   public float getFloat(String name) {
     return getFloat(name, 0);
@@ -885,11 +885,11 @@ public class XML implements Serializable {
 
 
   /**
-   * Sets the content of an element's attribute as a float.  A String specifies 
-   * the attribute name, while the float specifies the new content.
+   * Sets the content of an element's attribute as a <b>float</b>.  A <b>String</b> specifies 
+   * the attribute name, while the <b>float</b> specifies the new content.
    *
    * @webref xml:method
-   * @webBrief Sets the content of an attribute as a float
+   * @webBrief Sets the content of an attribute as a <b>float</b>
    */
   public void setFloat(String name, float value) {
     setString(name, String.valueOf(value));
@@ -941,11 +941,11 @@ public class XML implements Serializable {
 
 
   /**
-   * Returns the content of an element as an int. If there is no such content, 
+   * Returns the content of an element as an <b>int</b>. If there is no such content, 
    * either <b>null</b> or the provided default value is returned.
    *
    * @webref xml:method
-   * @webBrief Gets the content of an element as an int
+   * @webBrief Gets the content of an element as an <b>int</b>
    * @return the content.
    * @see XML#getContent()
    * @see XML#getFloatContent()
@@ -964,11 +964,11 @@ public class XML implements Serializable {
 
 
   /**
-   * Returns the content of an element as a float. If there is no such content, 
+   * Returns the content of an element as a <b>float</b>. If there is no such content, 
    * either <b>null</b> or the provided default value is returned.
    *
    * @webref xml:method
-   * @webBrief Gets the content of an element as a float
+   * @webBrief Gets the content of an element as a <b>float</b>
    * @return the content.
    * @see XML#getContent()
    * @see XML#getIntContent()
@@ -1019,7 +1019,7 @@ public class XML implements Serializable {
 
 
   /**
-   * Sets the element's content, which is specified as a String.
+   * Sets the element's content, which is specified as a <b>String</b>.
    *
    * @webref xml:method
    * @webBrief Sets the content of an element
@@ -1050,19 +1050,19 @@ public class XML implements Serializable {
 
 
   /**
-   * Takes an XML object and converts it to a String, formatting its content as
+   * Takes an <b>XML</b> object and converts it to a <b>String</b>, formatting its content as
    * specified with the <b>indent</b> parameter.<br />
    * <br />
    * If indent is set to -1, then the String is returned with no line breaks, no
-   * indentation, and no XML declaration.<br />
+   * indentation, and no <b>XML</b> declaration.<br />
    * <br />
-   * If indent is set to 0 or greater, then the String is returned with line
+   * If indent is set to 0 or greater, then the <b>String</b> is returned with line
    * breaks, and the specified number of spaces as indent values. Meaning, there
    * will be no indentation if 0 is specified, or each indent will be replaced
    * with the corresponding number of spaces: 1, 2, 3, and so on.
    *
    * @webref xml:method
-   * @webBrief Formats XML data as a String
+   * @webBrief Formats <b>XML</b> data as a <b>String</b>
    * @param indent -1 for a single line (and no declaration), >= 0 for indents and
    *               newlines
    * @return the content
@@ -1204,13 +1204,13 @@ public class XML implements Serializable {
 
 
   /**
-   * Takes an XML object and converts it to a String, using default formatting
+   * Takes an <b>XML</b> object and converts it to a <b>String</b>, using default formatting
    * rules (includes an XML declaration, line breaks, and two spaces for indents).
    * These are the same formatting rules used by <b>println()</b> when printing an
-   * XML object. This method produces the same results as using <b>format(2)</b>.
+   * <b>XML</b> object. This method produces the same results as using <b>format(2)</b>.
    *
    * @webref xml:method
-   * @webBrief Gets XML data as a String using default formatting
+   * @webBrief Gets <b>XML</b> data as a <b>String</b> using default formatting
    * @return the content
    * @see XML#format(int)
    */

--- a/core/src/processing/data/XML.java
+++ b/core/src/processing/data/XML.java
@@ -50,7 +50,7 @@ import processing.core.PApplet;
  *
  * @webref data:composite
  * @webBrief This is the base class used for the Processing XML library,
- *           representing a single node of an <b>XML</b> tree.
+ *           representing a single node of an <b>XML</b> tree
  * @see PApplet#loadXML(String)
  * @see PApplet#parseXML(String)
  * @see PApplet#saveXML(XML, String)

--- a/core/src/processing/opengl/PShader.java
+++ b/core/src/processing/opengl/PShader.java
@@ -37,7 +37,7 @@ import java.util.HashMap;
  * fragment shader. It's compatible with the P2D and P3D renderers, but not with
  * the default renderer. Use the <b>loadShader()</b> function to load your
  * shader code. [Note: It's strongly encouraged to use <b>loadShader()</b> to
- * create a PShader object, rather than calling the PShader constructor
+ * create a <b>PShader</b> object, rather than calling the <b>PShader</b> constructor
  * manually.]
  *
  * @webref rendering:shaders

--- a/core/src/processing/opengl/PShader.java
+++ b/core/src/processing/opengl/PShader.java
@@ -42,7 +42,7 @@ import java.util.HashMap;
  *
  * @webref rendering:shaders
  * @webBrief This class encapsulates a GLSL shader program, including a vertex
- *           and a fragment shader.
+ *           and a fragment shader
  */
 public class PShader implements PConstants {
   static protected final int POINT    = 0;

--- a/doclet/ReferenceGenerator/processingrefBuild.sh
+++ b/doclet/ReferenceGenerator/processingrefBuild.sh
@@ -11,17 +11,6 @@ REFERENCES_OUT_PATH=../../../processing-website/content/references/translations/
 echo "[REFERENCE GENERATOR] Source Path :: $PROCESSING_SRC_PATH"
 echo "[REFERENCE GENERATOR] Library Path :: $PROCESSING_LIB_PATH"
 
-
-echo "[REFERENCE GENERATOR] Removing previous version of the ref..."
-rm -rf $REFERENCES_OUT_PATH
-mkdir $REFERENCES_OUT_PATH
-mkdir $REFERENCES_OUT_PATH/processing
-mkdir $REFERENCES_OUT_PATH/io
-mkdir $REFERENCES_OUT_PATH/net
-mkdir $REFERENCES_OUT_PATH/serial
-mkdir $REFERENCES_OUT_PATH/sound
-mkdir $REFERENCES_OUT_PATH/video
-
 echo "[REFERENCE GENERATOR] Generating new javadocs..."
 javadoc -doclet ProcessingWeblet \
         -docletpath "bin/:lib/org.json.jar" \

--- a/doclet/ReferenceGenerator/src/writers/ClassWriter.java
+++ b/doclet/ReferenceGenerator/src/writers/ClassWriter.java
@@ -137,6 +137,9 @@ public class ClassWriter extends BaseWriter {
 			{
 				constructor = constructor.substring(0, constructor.length()-2) + ")";
 			}
+			else {
+				constructor += ")";
+			}
 			constructors.add(constructor);
 		}
 		return constructors;

--- a/doclet/ReferenceGenerator/src/writers/FieldWriter.java
+++ b/doclet/ReferenceGenerator/src/writers/FieldWriter.java
@@ -22,16 +22,22 @@ public class FieldWriter extends BaseWriter {
 	
 	public static void write(HashMap<String, String> vars, FieldDoc doc, String classname) throws IOException
 	{
-		String filename = getAnchor(doc);
 		TemplateWriter templateWriter = new TemplateWriter();
 
 		JSONObject fieldJSON = new JSONObject();
 
+		String fieldName;
+		if (getName(doc).contains("[]"))  {
+			fieldName = getName(doc).replace("[]", "");
+		} else {
+			fieldName = getName(doc);
+		}
+
 		String fileName;
 		if (classname != "") {
-			fileName = jsonDir + classname + "_" + getName(doc) + ".json";
+			fileName = jsonDir + classname + "_" + fieldName + ".json";
 		} else {
-			fileName = jsonDir + getName(doc) + ".json";
+			fileName = jsonDir + fieldName + ".json";
 		}
 
 		Tag[] tags = doc.tags(Shared.i().getWebrefTagName());
@@ -40,7 +46,6 @@ public class FieldWriter extends BaseWriter {
 
 		try
 		{
-			fieldJSON.put("type", "field");
 			fieldJSON.put("description", getWebDescriptionFromSource(doc));
 			fieldJSON.put("brief", getWebBriefFromSource(doc));
 			fieldJSON.put("category", category);
@@ -49,8 +54,9 @@ public class FieldWriter extends BaseWriter {
 			fieldJSON.put("related", getRelated(doc));
 		
 			if(Shared.i().isRootLevel(doc.containingClass())){
-				fieldJSON.put("classname", "");
+				fieldJSON.put("type", "other");
 			} else {
+				fieldJSON.put("type", "field");
 				fieldJSON.put("classanchor", getLocalAnchor(doc.containingClass()));
 				fieldJSON.put("parameters", getParentParam(doc));		
 				String syntax = templateWriter.writePartial("field.syntax.partial", getSyntax(doc));

--- a/java/libraries/io/src/processing/io/GPIO.java
+++ b/java/libraries/io/src/processing/io/GPIO.java
@@ -94,16 +94,16 @@ public class GPIO {
   /**
    *  Calls a function when the value of an input pin changes<br/>
    *  <br/>
-   *  The sketch method provided must accept a single integer (int) parameter, which is the
+   *  The sketch method provided must accept a single <b>integer</b> (int) parameter, which is the
    *  number of the GPIO pin that the interrupt occured on. As this method might be called
    *  at any time, including when drawing to the display window isn't permitted, it is best
-   *  to only set simple variables that are being responded to in the next draw() call, as
+   *  to only set simple variables that are being responded to in the next <b>draw()</b> call, as
    *  shown above. Calling functions of the Hardware I/O library at this point is certainly
    *  possible.<br/>
    *  <br/>
-   *  The mode parameter determines when the function will be called: GPIO.FALLING occurs 
-   *  when the level changes from high to low, GPIO.RISING when the level changes from low
-   *  to high, and GPIO.CHANGE when either occurs.
+   *  The mode parameter determines when the function will be called: <b>GPIO.FALLING</b> occurs 
+   *  when the level changes from high to low, <b>GPIO.RISING</b> when the level changes from low
+   *  to high, and <b>GPIO.CHANGE</b> when either occurs.
    *
    *  @param pin GPIO pin
    *  @param parent typically use "this"
@@ -333,7 +333,7 @@ public class GPIO {
    *  Allows interrupts to happen<br/>
    *  <br/>
    *  You can use <a href="GPIO_noInterrupts_.html">noInterrupts()</a> 
-   *  and interrupts() in tandem to make sure no interrupts are occuring 
+   *  and <b>interrupts()</b> in tandem to make sure no interrupts are occuring 
    *  while your sketch is doing a particular task. By default, interrupts 
    *  are enabled.
    *
@@ -351,7 +351,7 @@ public class GPIO {
   /**
    *  Prevents interrupts from happpening<br/>
    *  <br/>
-   *  You can use noInterrupts() and <a href="GPIO_interrupts_.html">interrupts()</a> 
+   *  You can use <b>noInterrupts()</b> and <a href="GPIO_interrupts_.html">interrupts()</a> 
    *  in tandem to make sure no interrupts are occuring while your sketch is doing a 
    *  particular task.<br/>
    *  br/>
@@ -529,9 +529,9 @@ public class GPIO {
   /**
    *  Waits for the value of an input pin to change<br/>
    *  <br/>
-   *  The mode parameter determines when the function will return: GPIO.FALLING occurs 
-   *  when the level changes from high to low, GPIO.RISING when the level changes from 
-   *  low to high, and GPIO.CHANGE when either occurs.<br/>
+   *  The mode parameter determines when the function will return: <b>GPIO.FALLING</b> occurs 
+   *  when the level changes from high to low, <b>GPIO.RISING</b> when the level changes from 
+   *  low to high, and <b>GPIO.CHANGE</b> when either occurs.<br/>
    *  <br/>
    *  The optional timeout parameter determines how many milliseconds the function will 
    *  wait at the most. If the value of the input pin hasn't changed at this point, an 
@@ -550,9 +550,9 @@ public class GPIO {
   /**
    *  Waits for the value of an input pin to change<br/>
    *  <br/>
-   *  The mode parameter determines when the function will return: GPIO.FALLING occurs 
-   *  when the level changes from high to low, GPIO.RISING when the level changes from 
-   *  low to high, and GPIO.CHANGE when either occurs.<br/>
+   *  The mode parameter determines when the function will return: <b>GPIO.FALLING</b> occurs 
+   *  when the level changes from high to low, <b>GPIO.RISING</b> when the level changes from 
+   *  low to high, and <b>GPIO.CHANGE</b> when either occurs.<br/>
    *  <br/>
    *  The optional timeout parameter determines how many milliseconds the function will 
    *  wait at the most. If the value of the input pin hasn't changed at this point, an 

--- a/java/libraries/io/src/processing/io/I2C.java
+++ b/java/libraries/io/src/processing/io/I2C.java
@@ -124,7 +124,7 @@ public class I2C {
    * time.
    * 
    * @webref I2C
-   * @webBrief Closes the I2C device.
+   * @webBrief Closes the I2C device
    */
   public void close() {
     if (NativeInterface.isSimulated()) {
@@ -155,7 +155,7 @@ public class I2C {
    * @see beginTransmission
    * @see write
    * @webref I2C
-   * @webBrief Ends the current transmissions.
+   * @webBrief Ends the current transmissions
    */
   public void endTransmission() {
     if (!transmitting) {
@@ -223,7 +223,7 @@ public class I2C {
    * @see write
    * @see endTransmission
    * @webref I2C
-   * @webBrief Read bytes from the attached device.
+   * @webBrief Read bytes from the attached device
    */
   public byte[] read(int len) {
     if (!transmitting) {
@@ -261,7 +261,7 @@ public class I2C {
    * @see read
    * @see endTransmission
    * @webref I2C
-   * @webBrief Add bytes to be written to the device.
+   * @webBrief Add bytes to be written to the device
    */
   public void write(byte[] out) {
     if (!transmitting) {

--- a/java/libraries/io/src/processing/io/I2C.java
+++ b/java/libraries/io/src/processing/io/I2C.java
@@ -150,7 +150,7 @@ public class I2C {
    * <br/>
    * This executes any queued writes. <a href="I2C_read_.html">Read()</a>
    * implicitly ends the current transmission as well, hence calling
-   * endTransmission() afterwards is not necessary.
+   * <b>endTransmission()</b> afterwards is not necessary.
    * 
    * @see beginTransmission
    * @see write
@@ -212,10 +212,10 @@ public class I2C {
   /**
    * Read bytes from the attached device<br/>
    * <br/>
-   * You must call beginTransmission() before calling this function. This function
+   * You must call <b>beginTransmission()</b> before calling this function. This function
    * also ends the current transmission and sends any data that was queued using
-   * write() before. It is not necessary to call
-   * <a href="I2C_endTransmission_.html">endTransmission()</a> after read().
+   * <b>write()</b> before. It is not necessary to call
+   * <a href="I2C_endTransmission_.html">endTransmission()</a> after <b>read()</b>.
    * 
    * @param len number of bytes to read
    * @return bytes read from device
@@ -253,8 +253,8 @@ public class I2C {
   /**
    * Add bytes to be written to the device<br/>
    * <br/>
-   * You must call beginTransmission() before calling this function. The actual
-   * writing takes part when read() or endTransmission() is being called.
+   * You must call <b>beginTransmission()</b> before calling this function. The actual
+   * writing takes part when <b>read()</b> or <b>endTransmission()</b> is being called.
    * 
    * @param out bytes to be written
    * @see beginTransmission

--- a/java/libraries/io/src/processing/io/SoftwareServo.java
+++ b/java/libraries/io/src/processing/io/SoftwareServo.java
@@ -83,10 +83,10 @@ public class SoftwareServo {
   /**
    * Attaches a servo motor to a GPIO pin<br/>
    * <br/>
-   * You must call this function before calling write(). Note that the servo motor
-   * will only be instructed to move after the first time write() is called.<br/>
+   * You must call this function before calling <b>write()</b>. Note that the servo motor
+   * will only be instructed to move after the first time <b>write()</b> is called.<br/>
    * <br/>
-   * The optional parameters minPulse and maxPulse control the minimum and maximum
+   * The optional parameters <b>minPulse</b> and <b>maxPulse</b> control the minimum and maximum
    * pulse width durations. The default values, identical to those of Arduino's
    * Servo class, should be compatible with most servo motors.
    * 
@@ -105,8 +105,8 @@ public class SoftwareServo {
   /**
    * Attaches a servo motor to a GPIO pin<br/>
    * <br/>
-   * You must call this function before calling write(). Note that the servo motor
-   * will only be instructed to move after the first time write() is called.<br/>
+   * You must call this function before calling <b>write()</b>. Note that the servo motor
+   * will only be instructed to move after the first time <b>write()</b> is called.<br/>
    * <br/>
    * The optional parameters minPulse and maxPulse control the minimum and maximum
    * pulse width durations. The default values, identical to those of Arduino's

--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -37,7 +37,7 @@ import java.net.*;
    * listening on a different port, an exception is thrown.
    * 
  * @webref client
- * @webBrief The client class is used to create client Objects which connect to a server to exchange data. 
+ * @webBrief The client class is used to create client Objects which connect to a server to exchange data
  * @instanceName client any variable of type Client
  * @usage Application
  * @see_external LIB_net/clientEvent
@@ -321,7 +321,7 @@ public class Client implements Runnable {
    * 
    * @webref client
    * @usage application
-   * @webBrief Returns the IP address of the machine as a String
+   * @webBrief Returns the IP address of the machine as a <b>String</b>
    */
   public String ip() {
     if (socket != null){
@@ -422,7 +422,7 @@ public class Client implements Runnable {
    * 
    * @webref client
    * @usage application
-   * @webBrief Reads a group of bytes from the buffer.
+   * @webBrief Reads a group of bytes from the buffer
    */
   public byte[] readBytes() {
     synchronized (bufferLock) {
@@ -596,7 +596,7 @@ public class Client implements Runnable {
 
   /**
    * 
-   * Returns the all the data from the buffer as a String. This method 
+   * Returns the all the data from the buffer as a <b>String</b>. This method 
    * assumes the incoming characters are ASCII. If you want to transfer 
    * Unicode data, first convert the String to a byte stream in the 
    * representation of your choice (i.e. UTF8 or two-byte Unicode data), and 
@@ -604,7 +604,7 @@ public class Client implements Runnable {
    * 
    * @webref client
    * @usage application
-   * @webBrief Returns the buffer as a String
+   * @webBrief Returns the buffer as a <b>String</b>
    */
   public String readString() {
     byte b[] = readBytes();
@@ -626,7 +626,7 @@ public class Client implements Runnable {
    * 
    * @webref client
    * @usage application
-   * @webBrief Returns the buffer as a String up to and including a particular character
+   * @webBrief Returns the buffer as a <b>String</b> up to and including a particular character
    * @param interesting character designated to mark the end of the data
    */
   public String readStringUntil(int interesting) {
@@ -644,7 +644,7 @@ public class Client implements Runnable {
    * 
    * @webref client
    * @usage application
-   * @webBrief  Writes bytes, chars, ints, bytes[], Strings
+   * @webBrief  Writes <b>bytes</b>, <b>chars</b>, <b>ints</b>, <b>bytes[]</b>, <b>Strings</b>
    * @param data data to write
    */
   public void write(int data) {  // will also cover char

--- a/java/libraries/net/src/processing/net/Server.java
+++ b/java/libraries/net/src/processing/net/Server.java
@@ -44,7 +44,7 @@ import java.net.*;
  * @webref server
  * @usage application
  * @webBrief The server class is used to create server objects which send 
- * and receives data to and from its associated clients (other programs connected to it). 
+ * and receives data to and from its associated clients (other programs connected to it)
  * @instanceName server  	any variable of type Server
  */
 public class Server implements Runnable {
@@ -118,7 +118,7 @@ public class Server implements Runnable {
    * Disconnect a particular client.
    * 
    * @webref server
-   * @webBrief Disconnect a particular client.
+   * @webBrief Disconnect a particular client
    * @param client the client to disconnect
    */
   public void disconnect(Client client) {
@@ -188,7 +188,7 @@ public class Server implements Runnable {
    * into any trouble.
    * 
    * @webref server
-   * @webBrief Return true if this server is still active.
+   * @webBrief Return <b>true</b> if this server is still active
    */
   public boolean active() {
     return thread != null;
@@ -215,7 +215,7 @@ public class Server implements Runnable {
    * Returns the next client in line with a new message.
    * 
    * @webref server
-   * @webBrief Returns the next client in line with a new message.
+   * @webBrief Returns the next client in line with a new message
    * @usage application
    */
   public Client available() {
@@ -255,7 +255,7 @@ public class Server implements Runnable {
    * is still running. Otherwise, it will be automatically be shut down by the 
    * host PApplet using dispose(), which is identical. 
    * @webref server
-   * @webBrief Disconnects all clients and stops the server.
+   * @webBrief Disconnects all clients and stops the server
    * @usage application
    */
   public void stop() {

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -198,10 +198,10 @@ public class Serial implements SerialPortEventListener {
 
 
   /**
-   * Sets the number of bytes to buffer before calling serialEvent()
+   * Sets the number of bytes to buffer before calling <b>serialEvent()</b>
    * @generate Serial_buffer.xml
    * @webref serial
-   * @webBrief Sets the number of bytes to buffer before calling serialEvent()
+   * @webBrief Sets the number of bytes to buffer before calling <b>serialEvent()</b>
    * @usage web_application
    * @param size number of bytes to buffer
    */
@@ -722,7 +722,7 @@ public class Serial implements SerialPortEventListener {
 
 
   /**
-   * Writes bytes, chars, ints, bytes[], Strings to the serial port
+   * Writes <b>bytes</b>, <b>chars</b>, <b>ints</b>, <b>bytes[]</b>, <b>Strings</b> to the serial port
    * 
    * <h3>Advanced</h3>
    * Write a String to the output. Note that this doesn't account
@@ -737,7 +737,7 @@ public class Serial implements SerialPortEventListener {
    * (i.e. UTF8 or two-byte Unicode data), and send it as a byte array.
    *
    * @webref serial
-   * @webBrief Writes bytes, chars, ints, bytes[], Strings to the serial port
+   * @webBrief Writes <b>bytes</b>, <b>chars</b>, <b>ints</b>, <b>bytes[]</b>, <b>Strings</b> to the serial port
    * @usage web_application
    * @param src data to write
    */

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -38,7 +38,7 @@ import jssc.*;
  * Class for sending and receiving data using the serial communication protocol.
  * 
  * @webref serial
- * @webBrief Class for sending and receiving data using the serial communication protocol.
+ * @webBrief Class for sending and receiving data using the serial communication protocol
  * @instanceName serial any variable of type Serial
  * @usage Application
  * @see_external LIB_serial/serialEvent
@@ -189,7 +189,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_available.xml
    * @webref serial
-   * @webBrief Returns the number of bytes available.
+   * @webBrief Returns the number of bytes available
    * @usage web_application
    */
   public int available() {
@@ -215,7 +215,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_bufferUntil.xml
    * @webref serial
-   * @webBrief Sets a specific byte to buffer until before calling <b>serialEvent()</b>.
+   * @webBrief Sets a specific byte to buffer until before calling <b>serialEvent()</b>
    * @usage web_application
    * @param inByte the value to buffer until
    */
@@ -230,7 +230,7 @@ public class Serial implements SerialPortEventListener {
    *
    * @generate Serial_clear.xml
    * @webref serial
-   * @webBrief Empty the buffer, removes all the data stored there.
+   * @webBrief Empty the buffer, removes all the data stored there
    * @usage web_application
    */
   public void clear() {
@@ -273,7 +273,7 @@ public class Serial implements SerialPortEventListener {
    * and clears the buffer. Useful when you just want the most
    * recent value sent over the port.
    * @webref serial
-   * @webBrief Returns last byte received or -1 if there is none available.
+   * @webBrief Returns last byte received or -1 if there is none available
    * @usage web_application
    */
   public int last() {
@@ -295,7 +295,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_lastChar.xml
    * @webref serial
-   * @webBrief Returns the last byte received as a char or -1 if there is none available.
+   * @webBrief Returns the last byte received as a char or -1 if there is none available
    * @usage web_application
    */
   public char lastChar() {
@@ -309,7 +309,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_list.xml
    * @webref serial
-   * @webBrief Gets a list of all available serial ports.
+   * @webBrief Gets a list of all available serial ports
    * @usage web_application
    */
   public static String[] list() {
@@ -326,7 +326,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_read.xml
    * @webref serial
-   * @webBrief Returns a number between 0 and 255 for the next byte that's waiting in the buffer.
+   * @webBrief Returns a number between 0 and 255 for the next byte that's waiting in the buffer
    * @usage web_application
    */
   public int read() {
@@ -354,7 +354,7 @@ public class Serial implements SerialPortEventListener {
    * <b>byteBuffer</b>, only those that fit are read.
    * @generate Serial_readBytes.xml
    * @webref serial
-   * @webBrief Reads a group of bytes from the buffer or <b>null</b> if there are none available.
+   * @webBrief Reads a group of bytes from the buffer or <b>null</b> if there are none available
    * @usage web_application
    */
   public byte[] readBytes() {
@@ -446,7 +446,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_readBytesUntil.xml
    * @webref serial
-   * @webBrief Reads from the port into a buffer of bytes up to and including a particular character. 
+   * @webBrief Reads from the port into a buffer of bytes up to and including a particular character
    * @usage web_application
    * @param inByte character designated to mark the end of the data
    */
@@ -532,7 +532,7 @@ public class Serial implements SerialPortEventListener {
    *
    * @generate Serial_readChar.xml
    * @webref serial
-   * @webBrief Returns the next byte in the buffer as a char.
+   * @webBrief Returns the next byte in the buffer as a char
    * @usage web_application
    */
   public char readChar() {
@@ -541,14 +541,14 @@ public class Serial implements SerialPortEventListener {
 
 
   /**
-   * Returns all the data from the buffer as a String or <b>null</b> if there is nothing available. 
+   * Returns all the data from the buffer as a <b>String</b> or <b>null</b> if there is nothing available. 
    * This method assumes the incoming characters are ASCII. If you want to transfer Unicode data, 
    * first convert the String to a byte stream in the representation of your choice (i.e. UTF8 or 
    * two-byte Unicode data), and send it as a byte array.
    *
    * @generate Serial_readString.xml
    * @webref serial
-   * @webBrief Returns all the data from the buffer as a String or <b>null</b> if there is nothing available.
+   * @webBrief Returns all the data from the buffer as a <b>String</b> or <b>null</b> if there is nothing available
    * @usage web_application
    */
   public String readString() {
@@ -570,7 +570,7 @@ public class Serial implements SerialPortEventListener {
    * (i.e. UTF8 or two-byte Unicode data), and send it as a byte array.
    *
    * @webref serial
-   * @webBrief Combination of <b>readBytesUntil()</b> and <b>readString()</b>.
+   * @webBrief Combination of <b>readBytesUntil()</b> and <b>readString()</b>
    * @usage web_application
    * @param inByte character designated to mark the end of the data
    */
@@ -594,7 +594,7 @@ public class Serial implements SerialPortEventListener {
    *
    * @generate serialEvent.xml
    * @webref serial_event
-   * @webBrief Called when data is available.
+   * @webBrief Called when data is available
    * @usage web_application
    * @param event the port where new data is available
    */
@@ -679,7 +679,7 @@ public class Serial implements SerialPortEventListener {
    * 
    * @generate Serial_stop.xml
    * @webref serial
-   * @webBrief Stops data communication on this port.
+   * @webBrief Stops data communication on this port
    * @usage web_application
    */
   public void stop() {


### PR DESCRIPTION
This PR makes changes to the Doclet and code comments in the java files.

In the Doclet it:

1. fixes missing `)` in constructor name for classes
2. removes `[]` in field names
3. changes type `field` to type `other` for references that don't belong to classes (such as constants, and system variables)
4. adjusts `processingrefBuild.sh` so that it overwrites individual files instead of folders. This will prevent deleting java references that are not generated from the processing code. 

In code comments it:

1. adds `<b></b>` tags to other references mentioned, and reserved words in reference descriptions and brief descriptions where it was missing
2. removes the dot at the end of the brief descriptions