### PR TITLE
Calls to `unregisterMethod` should null out object/method pairs instead of shortening the object and method arrays

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1367,6 +1367,10 @@ public class PApplet implements PConstants {
 
     void handle(Object[] args) {
       for (int i = 0; i < count; i++) {
+        // skip nulled out object/method pairs
+        if (methods[i] == null || objects[i] == null) {
+          continue;
+        }
         try {
           methods[i].invoke(objects[i], args);
         } catch (Exception e) {
@@ -1412,24 +1416,17 @@ public class PApplet implements PConstants {
 
 
     /**
-     * Removes first object/method pair matched (and only the first,
+     * Null out the first object/method pair matched (and only the first,
      * must be called multiple times if object is registered multiple times).
-     * Does not shrink array afterwards, silently returns if method not found.
+     * Does not shrink array. Silently returns if method not found.
      */
 //    public void remove(Object object, Method method) {
 //      int index = findIndex(object, method);
     public void remove(Object object) {
       int index = findIndex(object);
       if (index != -1) {
-        // shift remaining methods by one to preserve ordering
-        count--;
-        for (int i = index; i < count; i++) {
-          objects[i] = objects[i+1];
-          methods[i] = methods[i+1];
-        }
-        // clean things out for the gc's sake
-        objects[count] = null;
-        methods[count] = null;
+        objects[index] = null;
+        methods[index] = null;
       }
     }
 

--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1366,9 +1366,11 @@ public class PApplet implements PConstants {
 
 
     void handle(Object[] args) {
+      boolean nullsDetected = false;
       for (int i = 0; i < count; i++) {
         // skip nulled out object/method pairs
         if (methods[i] == null || objects[i] == null) {
+          nullsDetected = true;
           continue;
         }
         try {
@@ -1392,8 +1394,19 @@ public class PApplet implements PConstants {
           }
         }
       }
-    }
 
+      if (nullsDetected) {
+        int index;
+        while ((index = findIndex(null)) >= 0) {
+          // shift remaining methods by one to preserve ordering
+          count--;
+          for (int i = index; i < count; i++) {
+            objects[i] = objects[i+1];
+            methods[i] = methods[i+1];
+          }
+        }
+      }
+    }
 
     void add(Object object, Method method) {
       if (findIndex(object) == -1) {


### PR DESCRIPTION
This PR is to fix a bug I found in Processing related to calls to `unregisterMethod`.

The problem occurs if there are multiple registered objects and they try to unregister themselves during their method calls. I discovered this bug while working with the Processing Video library. The `Movie` class's [dispose() method](https://github.com/processing/processing-video/blob/321de067220763aedae8aa18ba3115448d381e91/src/processing/video/Movie.java#L117) unregisters the object's dispose call during its dispose call.

The `RegisteredMethods`'s `handle` method will loop through the object/method pairs, but if while doing that the `RegisteredMethods`'s `remove` method gets called, the `object` and `method` arrays will change size, and the for loop will skip an object/method pair. This is a problem for the Video library if multiple Movie objects are playing and the sketch exits. Dispose gets triggered and expensive Movie objects continue operating (and the JVM isn't getting shut down).

To reproduce the problem, try this code:

```
public class TestObject {
  
  private PApplet parent;
  private String name;

  public TestObject(PApplet parent, String name) {
    this.parent = parent;
    this.name = name;

    parent.registerMethod("post", this);
  }

  public void post() {
    System.out.println("in post for object " + name);

    if (parent.frameCount == 10) {
      parent.unregisterMethod("post", this);
    }
  }
}
```

With a sketch like this:

```
TestObject test1;
TestObject test2;

void setup() {
  test1 = TestObject(this, "object 1");
  test2 = TestObject(this, "object 2");
}

void draw() {
  if (frameCount == 20) {
    exit();
  }
}
```

The fix for this is for `remove` to null out the object/method pairs instead of shortening the arrays and for `handle` to check for nulls.

Alternatively one could leave `remove` alone and have `handle` make copies of the `method` and `object` arrays, so the arrays wouldn't change size while the for loop is iterating through the array items. But that would mean there would be 2 array copies every time `handle` gets called, which seems inefficient to me.

I'm happy to explore other fixes if this is not sufficient.
