### PR TITLE
Fix font choice other than Source Code Pro

### DIFF
--- a/app/src/processing/app/Preferences.java
+++ b/app/src/processing/app/Preferences.java
@@ -369,7 +369,7 @@ public class Preferences {
         Toolkit.getMonoFontName().equals(fontFamily)) {
       return Toolkit.getMonoFont(fontSize, style);
     }
-    return new Font(familyAttr, style, fontSize);
+    return new Font(fontFamily, style, fontSize);
   }
 
 


### PR DESCRIPTION
Choosing a font other than Source Code Pro in the options resulted in a variable-width fallback/default font being loaded in.

This was caused by the code effectively doing `new Font("editor.font.family", …)`, using the preference name variable, instead of the retrieved value.