### PR TITLE
Allow syntax error to try to complete text edits.

### DIFF
--- a/java/src/processing/mode/java/CompletionGenerator.java
+++ b/java/src/processing/mode/java/CompletionGenerator.java
@@ -1693,6 +1693,10 @@ public class CompletionGenerator {
                                                       final int lineNumber) {
     Messages.log("* preparePredictions");
 
+    if (ps.compilationUnit.types().size() == 0) {
+      return new ArrayList<>();
+    }
+
     ASTNode astRootNode = (ASTNode) ps.compilationUnit.types().get(0);
 
     // If the parsed code contains pde enhancements, take 'em out.

--- a/java/src/processing/mode/java/PreprocService.java
+++ b/java/src/processing/mode/java/PreprocService.java
@@ -419,7 +419,6 @@ public class PreprocService {
           .forEach(result.otherProblems::add);
 
       result.hasSyntaxErrors = true;
-      return result.build();
     }
 
     // Save off the imports

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -255,9 +255,20 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
   /**
    * Get the result of the last preprocessing.
    *
+   * @param issues The errors (if any) encountered.
    * @return The result of the last preprocessing.
    */
   public PreprocessorResult getResult() {
+    return getResult(new ArrayList<>());
+  }
+
+  /**
+   * Get the result of the last preprocessing with optional error.
+   *
+   * @param issues The errors (if any) encountered.
+   * @return The result of the last preprocessing.
+   */
+  public PreprocessorResult getResult(List<PdePreprocessIssue> issues) {
     List<ImportStatement> allImports = new ArrayList<>();
 
     allImports.addAll(coreImports);
@@ -277,7 +288,8 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
         allImports,
         allEdits,
         sketchWidth,
-        sketchHeight
+        sketchHeight,
+        issues
     );
   }
 

--- a/java/src/processing/mode/java/preproc/PdePreprocessor.java
+++ b/java/src/processing/mode/java/preproc/PdePreprocessor.java
@@ -208,19 +208,10 @@ public class PdePreprocessor {
       ));
       parser.setBuildParseTree(true);
       tree = parser.processingSketch();
-
-      if (preprocessIssues.size() > 0) {
-        return PreprocessorResult.reportPreprocessIssues(preprocessIssues);
-      }
     }
 
     ParseTreeWalker treeWalker = new ParseTreeWalker();
     treeWalker.walk(listener, tree);
-
-    // Check for issues encountered in walk
-    if (treeIssues.size() > 0) {
-      return PreprocessorResult.reportPreprocessIssues(treeIssues);
-    }
 
     // Return resulting program
     String outputProgram = listener.getOutputProgram();
@@ -229,7 +220,13 @@ public class PdePreprocessor {
 
     foundMain = listener.foundMain();
 
-    return listener.getResult();
+    if (preprocessIssues.size() > 0) {
+      return listener.getResult(preprocessIssues);
+    } else if (treeIssues.size() > 0) {
+      return listener.getResult(treeIssues);
+    } else {
+      return listener.getResult();
+    }
   }
 
   /**

--- a/java/src/processing/mode/java/preproc/PreprocessorResult.java
+++ b/java/src/processing/mode/java/preproc/PreprocessorResult.java
@@ -69,8 +69,8 @@ public class PreprocessorResult {
    * @param newSketchHeight The height of the sketch in pixels or special value like displayWidth;
    */
   public PreprocessorResult(PdePreprocessor.Mode newProgramType, int newHeaderOffset,
-        String newClassName, List<ImportStatement> newImportStatements, List<TextTransform.Edit> newEdits,
-        String newSketchWidth, String newSketchHeight) {
+        String newClassName, List<ImportStatement> newImportStatements,
+        List<TextTransform.Edit> newEdits, String newSketchWidth, String newSketchHeight) {
 
     if (newClassName == null) {
       throw new RuntimeException("Could not find main class");
@@ -82,6 +82,38 @@ public class PreprocessorResult {
     programType = newProgramType;
     edits = newEdits;
     preprocessIssues = new ArrayList<>();
+
+    sketchWidth = newSketchWidth;
+    sketchHeight = newSketchHeight;
+  }
+
+  /**
+   * Create a new preprocessing result with errors
+   *
+   * @param newProgramType The type of program that has be preprocessed.
+   * @param newHeaderOffset The offset (in number of chars) from the start of the program at which
+   *    the header finishes.
+   * @param newClassName The name of the class containing the sketch.
+   * @param newImportStatements The imports required for the sketch including defaults and core imports.
+   * @param newEdits The edits made during preprocessing.
+   * @param newSketchWidth The width of the sketch in pixels or special value like displayWidth;
+   * @param newSketchHeight The height of the sketch in pixels or special value like displayWidth;
+   */
+  public PreprocessorResult(PdePreprocessor.Mode newProgramType, int newHeaderOffset,
+        String newClassName, List<ImportStatement> newImportStatements,
+        List<TextTransform.Edit> newEdits, String newSketchWidth, String newSketchHeight,
+        List<PdePreprocessIssue> newPreprocessIssues) {
+
+    if (newClassName == null) {
+      throw new RuntimeException("Could not find main class");
+    }
+
+    headerOffset = newHeaderOffset;
+    className = newClassName;
+    importStatements = newImportStatements;
+    programType = newProgramType;
+    edits = newEdits;
+    preprocessIssues = newPreprocessIssues;
 
     sketchWidth = newSketchWidth;
     sketchHeight = newSketchHeight;


### PR DESCRIPTION
Do not stop trying to generate java code when there is a syntax error but also have the completion generator check that types are available.