### PR TITLE
Fix color in appearing in fully qualified names.

### DIFF
--- a/java/src/processing/mode/java/preproc/Processing.g4
+++ b/java/src/processing/mode/java/preproc/Processing.g4
@@ -4,7 +4,8 @@
  *	- changes main entry point to reflect sketch types 'static' | 'active'
  *	- adds support for type converter functions like "int()"
  *	- adds pseudo primitive type "color"
- *	- adds HTML hex notation with hash symbol: #ff5522 
+ *	- adds HTML hex notation with hash symbol: #ff5522
+ *  - allow color to appear as part of qualified names (like in imports)
  */
 
 grammar Processing;
@@ -47,8 +48,8 @@ variableDeclaratorId
 // https://github.com/processing/processing/issues/93
 // prevent from types being used as variable names
 warnTypeAsVariableName
-    :   primitiveType ('[' ']')* { 
-            notifyErrorListeners("Type names are not allowed as variable names: "+$primitiveType.text); 
+    :   primitiveType ('[' ']')* {
+            notifyErrorListeners("Type names are not allowed as variable names: "+$primitiveType.text);
         }
     ;
 
@@ -89,6 +90,10 @@ colorPrimitiveType
     :   'color'
     ;
 
+qualifiedName
+    : (IDENTIFIER | colorPrimitiveType) ('.' (IDENTIFIER | colorPrimitiveType))*
+    ;
+
 // added HexColorLiteral
 literal
     : integerLiteral
@@ -127,4 +132,3 @@ LINE_COMMENT
     ;
 
 CHAR_LITERAL:       '\'' (~['\\\r\n] | EscapeSequence)* '\''; // A bit nasty but let JDT tackle invalid chars
-

--- a/java/src/processing/mode/java/preproc/Processing.g4
+++ b/java/src/processing/mode/java/preproc/Processing.g4
@@ -5,7 +5,7 @@
  *	- adds support for type converter functions like "int()"
  *	- adds pseudo primitive type "color"
  *	- adds HTML hex notation with hash symbol: #ff5522
- *  - allow color to appear as part of qualified names (like in imports)
+ *      - allow color to appear as part of qualified names (like in imports)
  */
 
 grammar Processing;

--- a/java/src/processing/mode/java/preproc/Processing.g4
+++ b/java/src/processing/mode/java/preproc/Processing.g4
@@ -5,7 +5,7 @@
  *	- adds support for type converter functions like "int()"
  *	- adds pseudo primitive type "color"
  *	- adds HTML hex notation with hash symbol: #ff5522
- *      - allow color to appear as part of qualified names (like in imports)
+ *     - allow color to appear as part of qualified names (like in imports)
  */
 
 grammar Processing;

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -385,4 +385,9 @@ public class ParserTests {
     expectGood("smoothparamstatic");
   }
 
+  @Test
+  public void testColorInImport() {
+    expectGood("colorimport");
+  }
+
 }

--- a/java/test/resources/colorimport.expected
+++ b/java/test/resources/colorimport.expected
@@ -3,6 +3,8 @@ import processing.data.*;
 import processing.event.*;
 import processing.opengl.*;
 
+import test.color;
+
 import java.util.HashMap;
 import java.util.ArrayList;
 import java.io.File;
@@ -12,19 +14,18 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
-import test.color;
-
 public class colorimport extends PApplet {
 
     public void setup() {
+
+
 boolean test = true;
-int c1 = color(255, 255, 255);
-int c2 = test ? 0xFFA011CD : 0xC0C0C0C0;
-    noLoop();
+
+        noLoop();
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "color" };
+        String[] appletArgs = new String[] { "colorimport" };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/colorimport.expected
+++ b/java/test/resources/colorimport.expected
@@ -1,0 +1,34 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+import test.color;
+
+public class colorimport extends PApplet {
+
+    public void setup() {
+boolean test = true;
+int c1 = color(255, 255, 255);
+int c2 = test ? 0xFFA011CD : 0xC0C0C0C0;
+    noLoop();
+    }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "color" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/colorimport.expected
+++ b/java/test/resources/colorimport.expected
@@ -20,6 +20,8 @@ public class colorimport extends PApplet {
 
 
 boolean test = true;
+int c1 = color(255, 255, 255);
+int c2 = test ? 0xFFA011CD : 0xC0C0C0C0;
 
         noLoop();
     }

--- a/java/test/resources/colorimport.pde
+++ b/java/test/resources/colorimport.pde
@@ -1,0 +1,5 @@
+import test.color;
+
+boolean test = true;
+color c1 = color(255, 255, 255);
+color c2 = test ? #A011CD : #C0C0C0C0;

--- a/java/test/resources/colorimport.pde
+++ b/java/test/resources/colorimport.pde
@@ -1,3 +1,5 @@
 import test.color;
 
 boolean test = true;
+color c1 = color(255, 255, 255);
+color c2 = test ? #A011CD : #C0C0C0C0;

--- a/java/test/resources/colorimport.pde
+++ b/java/test/resources/colorimport.pde
@@ -1,5 +1,3 @@
 import test.color;
 
 boolean test = true;
-color c1 = color(255, 255, 255);
-color c2 = test ? #A011CD : #C0C0C0C0;


### PR DESCRIPTION
Addressing #240, allow color to appear in fully qualified names like as part of import statements. It's not the cleanest solution (other primitive types could not appear here) but I don't see too many alternatives.

