### PR TITLE
Enable JVM Font Antialiasing for Linux

### DIFF
--- a/build/linux/processing
+++ b/build/linux/processing
@@ -114,5 +114,5 @@ else
   cd "$APPDIR"
 
   #java -splash:lib/about-1x.png -Djna.nosys=true -Djava.library.path=lib:modes/java/libraries/javafx/library/linux64 --module-path=modes/java/libraries/javafx/library/linux64/modules --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web -Xmx512m processing.app.Base "$SKETCH" &
-  java -Djna.nosys=true -Dpython.console.encoding=UTF-8 -Djava.library.path=lib:modes/java/libraries/javafx/library/linux64 --module-path=modes/java/libraries/javafx/library/linux64/modules --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web -Xmx512m processing.app.ui.Splash "$SKETCH" &
+  java -Dawt.useSystemAAFontSettings=lcd -Djna.nosys=true -Dpython.console.encoding=UTF-8 -Djava.library.path=lib:modes/java/libraries/javafx/library/linux64 --module-path=modes/java/libraries/javafx/library/linux64/modules --add-modules=javafx.base,javafx.controls,javafx.fxml,javafx.graphics,javafx.media,javafx.swing,javafx.web -Xmx512m processing.app.ui.Splash "$SKETCH" &
 fi


### PR DESCRIPTION
Should add smoothness for fonts in the Processing GUI most of the time.
With change: 
![image](https://user-images.githubusercontent.com/3101450/136100302-be6f1350-c567-4422-aef6-91218e7b8126.png)
Without change:
![image](https://user-images.githubusercontent.com/3101450/136100428-3859ab27-f3d6-4dac-8d78-b45580bcc58a.png)

(GitHub compressed images, but the difference is still visible)