### PR TITLE
Support for multiple GL windows with resource sharing

### DIFF
--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -51,6 +51,7 @@ import com.jogamp.opengl.GLCapabilitiesImmutable;
 import com.jogamp.opengl.GLContext;
 import com.jogamp.opengl.GLDrawable;
 import com.jogamp.opengl.fixedfunc.GLMatrixFunc;
+import com.jogamp.opengl.GLRendererQuirks;
 import com.jogamp.opengl.glu.GLU;
 import com.jogamp.opengl.glu.GLUtessellator;
 import com.jogamp.opengl.glu.GLUtessellatorCallbackAdapter;
@@ -180,6 +181,11 @@ public class PJOGL extends PGL {
 
   public GLCapabilitiesImmutable getCaps() {
     return capabilities;
+  }
+
+
+  public boolean needSharedObjectSync() {
+    return gl.getContext().hasRendererQuirk(GLRendererQuirks.NeedSharedObjectSync);
   }
 
 

--- a/core/src/processing/opengl/PJOGL.java
+++ b/core/src/processing/opengl/PJOGL.java
@@ -129,6 +129,8 @@ public class PJOGL extends PGL {
   }
 
 
+  private static boolean forceSharedObjectSync = true;
+
   ///////////////////////////////////////////////////////////////
 
   // Initialization, finalization
@@ -185,7 +187,7 @@ public class PJOGL extends PGL {
 
 
   public boolean needSharedObjectSync() {
-    return gl.getContext().hasRendererQuirk(GLRendererQuirks.NeedSharedObjectSync);
+    return forceSharedObjectSync || gl.getContext().hasRendererQuirk(GLRendererQuirks.NeedSharedObjectSync);
   }
 
 


### PR DESCRIPTION
As discussed in https://github.com/processing/processing4/issues/312

The less elegant aspect of this implementation is the use of a static list of animators to store all the animators created so far. When the the first window is closed, it can stop all the other animators, otherwise there will be an exception.

