### PR TITLE
Set Processing Icon in Splash

### DIFF
--- a/app/src/processing/app/ui/Splash.java
+++ b/app/src/processing/app/ui/Splash.java
@@ -24,6 +24,10 @@ public class Splash extends JFrame {
 
 
   private Splash(File imageFile, boolean hidpi) {
+    
+    // change default java window icon to processing icon
+    processing.app.ui.Toolkit.setIcon(this);
+    
     this.image =
       Toolkit.getDefaultToolkit().createImage(imageFile.getAbsolutePath());
 


### PR DESCRIPTION
Fixes #297

Verified taskbar icon after build and run, now it is showing processing icon during splash window.