### PR TITLE
Portable settings

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -27,6 +27,7 @@ import java.awt.*;
 import java.awt.event.ActionListener;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.List;
@@ -1949,10 +1950,36 @@ public class Base {
    * preference for 3.0a3 because we need this to be stable.
    */
   static public File getSettingsFolder() {
+    File settingFolderFile = Platform.getContentFile("settingPath.txt");
     File settingsFolder = null;
 
     try {
-      settingsFolder = Platform.getSettingsFolder();
+      if (settingFolderFile != null) {
+        if (!settingFolderFile.exists() && !settingFolderFile.createNewFile()) {
+          throw new IOException();
+        }
+        String[] folderFileContent = PApplet.loadStrings(settingFolderFile);
+        if (folderFileContent != null && folderFileContent.length > 0) {
+          String path = folderFileContent[0];
+          if (!path.startsWith("/") ||
+              path.startsWith("./") ||
+              path.startsWith("../")) {
+            settingsFolder = Platform.getContentFile(path);
+          } else {
+            settingsFolder = new File(path);
+          }
+        }
+      }
+    } catch (IOException e) {
+      Messages.showTrace("An rare and unknowable thing happened",
+                         "Could not create or read the settings path file.",
+                         e, false);
+    }
+
+    try {
+      if (settingsFolder == null) {
+        settingsFolder = Platform.getSettingsFolder();
+      }
 
       // create the folder if it doesn't exist already
       if (!settingsFolder.exists()) {


### PR DESCRIPTION
## The Feature
Added a "settingsPath.txt" file inside of the App itself that, when a path is put in, uses the given path to redirect the settings from the usual %AppData%/Processing folder to the given folder.

## What it does
It modifies the `getSettingsFolder` method in `Base` that provides the folder so that it first checks (and creates) the settingsPath file in the app folder. If this file then contains a line, it will try using this String as the setting folder (relative paths possible). If the file is empty or doesn't exist, it will use the default directory for the settings. 

## Why do I want that feature?
>https://github.com/processing/processing4/pull/357
>I need this feature in the program because my Teacher wants to use it in our school and I don't want to manually search and install every library I want. I will also create a pr for a hopefully portable version of the app by moving the settings into the app or (more likely) creating a file inside of the app containing the path to the settings file (needed because %AppData% resets every time rebooting a school PC). Please tell me if you have a solution in mind so I can build it to your wishes.

## Sidenotes
- I know you don't want too much code in the Base class (you mentioned it somewhere) but I see this as the best solution.
- If you take the windows and linux versions of the app and edit each app's setting paths it gets fully portable across systems :D

## Draft
- [ ] Will follow up whit GUI implementation soon. Under the sketch location or at the bottom?
- [ ] Maybe a parser for the relative paths to make them less confusing: 
`/home/apps/Processing.app/../../foo/bar/` -> `/home/foo/bar/`
- [ ] Check if relative path validation works on windows. If not.. Well a few if statements will do.
- [ ] Generally test feature on Windows since I am on a Mac.