### PR TITLE
Startup performance improvements

### DIFF
--- a/app/src/processing/app/ui/Toolkit.java
+++ b/app/src/processing/app/ui/Toolkit.java
@@ -1222,8 +1222,10 @@ public class Toolkit {
     Font font = Font.createFont(Font.TRUETYPE_FONT, input);
     input.close();
 
-    GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
-    ge.registerFont(font);
+    new Thread(() -> {
+      GraphicsEnvironment ge = GraphicsEnvironment.getLocalGraphicsEnvironment();
+      ge.registerFont(font);
+    }, "FontRegisterer").start();
 
     return font.deriveFont((float) size);
   }


### PR DESCRIPTION
## How and how much time can we save
I followed your timing Todos and commented code, found that these two lines of code take about two seconds to run on the first call. 
https://github.com/processing/processing4/blob/5fef895e84c20f4d30ed65a426e37c3c7397e5c7/app/src/processing/app/ui/Toolkit.java#L1225-L1226 By putting the font loading into a thread I was able to reduce the startup time by about two seconds. 
## I don't think this will cause bugs because
1) According to my timings it will be done before the GUI loads anyways
2) It is not responsible for the GUI font itself but only for the Font Setting - Even if it does fail it will be fine after reopeing the settings panel.
## Difference in timings
Reports are seperated by three hyphens (---)
Notice the first font call (Mirroring in ManagerFrame->ContribInit->All)
|Old|New|
|---|---|
|![image](https://user-images.githubusercontent.com/76821666/150651017-d76b344d-54a3-4b5e-b3cf-10f5e99a42a6.png)|![image](https://user-images.githubusercontent.com/76821666/150651038-faf418af-4317-40ce-bd95-39eb679a9e66.png)|

## I want to test that
I also comited and pushed my timing code extending your code on this branch: [codeac-timings](https://github.com/Code-Ac/processing4/tree/codeac-timings/)
Merge the [codeac-startup-performance](https://github.com/Code-Ac/processing4/tree/codeac-startup-performance/) branch into it to see the difference in the first Font call.