### PR TITLE
Add ctrl and alt deletion

### DIFF
--- a/java/src/processing/mode/java/CompletionGenerator.java
+++ b/java/src/processing/mode/java/CompletionGenerator.java
@@ -1300,18 +1300,11 @@ public class CompletionGenerator {
 
     if (isImported) return false;
 
-    if (impName.startsWith("processing")) {
-      if (mode.includeSuggestion(impName)) {
-        return false;
-      } else if (mode.excludeSuggestion(impName)) {
-        return true;
-      }
-    } else if (impName.startsWith("java")) {
-      if (mode.includeSuggestion(impName)) {
-        return false;
-      }
+    if (mode.excludeSuggestion(impName)) {
+      return true;
+    } else if (mode.includeSuggestion(impName)) {
+      return false;
     }
-
     return true;
   }
 

--- a/java/src/processing/mode/java/JavaMode.java
+++ b/java/src/processing/mode/java/JavaMode.java
@@ -334,11 +334,11 @@ public class JavaMode extends Mode {
       "processing.opengl.PShader",
       "processing.opengl.PGL",
 
-      "java.util.ArrayList",
-      "java.io.BufferedReader",
-      "java.util.HashMap",
-      "java.io.PrintWriter",
-      "java.lang.String"
+      "classes.java.util.ArrayList",
+      "classes.java.io.BufferedReader",
+      "classes.java.util.HashMap",
+      "classes.java.io.PrintWriter",
+      "classes.java.lang.String"
     };
   }
 


### PR DESCRIPTION
Added the option to delete whole lines or just words by holding ctrl (on mac cmd) or alt while pressing the backspace key. Dosen't need much explanation.

Also fixed Autocompletion not including classes not being in the processing package. On top of that, classes had wrong names.