### PR TITLE
Fullscreen argument preproc fix

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -78,6 +78,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
   private String pixelDensity;
   private String smoothParam;
   private String sketchRenderer = null;
+  private String fullscreenArgs = "";
   private String sketchOutputFilename = null;
 
   private boolean sizeRequiresRewrite = false;
@@ -720,9 +721,17 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
       thisRequiresRewrite = true;
       sizeIsFullscreen = true;
 
+      StringJoiner fullscreenArgsBuilder = new StringJoiner(", ");
+
       if (argsContext.getChildCount() > 0) {
-        sketchRenderer = argsContext.getChild(0).getText();
+        fullscreenArgsBuilder.add(argsContext.getChild(0).getText());
       }
+
+      if (argsContext.getChildCount() > 2) {
+        fullscreenArgsBuilder.add(argsContext.getChild(2).getText());
+      }
+
+      fullscreenArgs = fullscreenArgsBuilder.toString();
     }
 
     if (thisRequiresRewrite) {
@@ -1153,8 +1162,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
     if (sizeRequiresRewrite) {
       if (sizeIsFullscreen) {
-        String fullscreenInner = sketchRenderer == null ? "" : sketchRenderer;
-        settingsInner.add(String.format("fullScreen(%s);", fullscreenInner));
+        settingsInner.add(String.format("fullScreen(%s);", fullscreenArgs));
       } else {
 
         if (sketchWidth.isEmpty() || sketchHeight.isEmpty()) {

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -326,6 +326,11 @@ public class ParserTests {
   }
 
   @Test
+  public void fullscreenArg() {
+    expectGood("fullscreen_arg", true);
+  }
+
+  @Test
   public void customMain() {
     expectGood("custommain", true);
   }

--- a/java/test/resources/fullscreen_arg.expected
+++ b/java/test/resources/fullscreen_arg.expected
@@ -1,0 +1,33 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class fullscreen extends PApplet {
+
+    public void setup() {
+/* size commented out by preprocessor */;
+
+        noLoop();
+    }
+
+    public void settings() { fullScreen(FX2D, 2); }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "fullscreen_arg" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/fullscreen_arg.expected
+++ b/java/test/resources/fullscreen_arg.expected
@@ -12,7 +12,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 
-public class fullscreen extends PApplet {
+public class fullscreen_arg extends PApplet {
 
     public void setup() {
 /* size commented out by preprocessor */;

--- a/java/test/resources/fullscreen_arg.pde
+++ b/java/test/resources/fullscreen_arg.pde
@@ -1,0 +1,1 @@
+fullScreen(FX2D, 2);

--- a/java/test/resources/fullscreen_noarg.expected
+++ b/java/test/resources/fullscreen_noarg.expected
@@ -1,0 +1,33 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class fullscreen_noarg extends PApplet {
+
+    public void setup() {
+/* size commented out by preprocessor */;
+
+        noLoop();
+    }
+
+    public void settings() { fullScreen(); }
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "fullscreen_noarg" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/fullscreen_noarg.pde
+++ b/java/test/resources/fullscreen_noarg.pde
@@ -1,0 +1,1 @@
+fullScreen();


### PR DESCRIPTION
As noticed in #352, the fullscreen rewrite only was carrying 1 argument over. This adds tests for an additional argument lengths and resolves the issue for the two argument case.