### PR TITLE
Renamed parameters controlling GL buffer settings

### DIFF
--- a/core/src/processing/opengl/PGL.java
+++ b/core/src/processing/opengl/PGL.java
@@ -77,16 +77,6 @@ public abstract class PGL {
   protected static boolean USE_DIRECT_BUFFERS = true;
   protected static int MIN_DIRECT_BUFFER_SIZE = 1;
 
-  /** Controls the use of buffer object streaming. In combination with use direct buffers,
-   * the only advantage of enabling it in immediate mode would be to reduce memory footprint
-   * since the direct vertex buffers would not be allocated, simply mapped from the OpenGL
-   * objects and thus only the vertex arrays would be created.
-   * In the case of the retained mode (PShape), memory footprint would be reduced (for the same
-   * reason) but it may enable some speed ups when editing a geometry in within a being/end
-   * tessellation update block. */
-  static public boolean USE_BUFFER_OBJECT_STREAMING_IN_IMMEDIATE_MODE = false;
-  static public boolean USE_BUFFER_OBJECT_STREAMING_IN_RETAINED_MODE = true;
-
   /** Enables/disables mipmap use. */
   protected static boolean MIPMAPS_ENABLED = true;
 
@@ -139,15 +129,33 @@ public abstract class PGL {
 
   // ........................................................
 
-  // These variables are left public so advanced users can experiment with different
-  // usage modes and access policies controlling the buffer data store:
+  // These parameters are left public so advanced users can experiment with different
+  // configurations of buffer object streaming, buffer usage modes and access policies.
 
-  // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml
-  static public int glUsageRetained;
-  static public int glUsageImmediate;
+  /** Controls the use of buffer object streaming:
+   * https://www.khronos.org/opengl/wiki/Buffer_Object_Streaming
+   * In combination with use direct buffers,
+   * the only advantage of enabling it in immediate mode would be to reduce memory footprint
+   * since the direct vertex buffers would not be allocated, simply mapped from the OpenGL
+   * objects and thus only the vertex arrays would be created.
+   * In the case of the retained mode (PShape), memory footprint would be reduced (for the same
+   * reason) but it may enable some speed-ups when editing a geometry in within a being/end
+   * tessellation update block. */
+  static public boolean bufferStreamingImmediate = false;
+  static public boolean bufferStreamingRetained = true;
 
-  // https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml
-  static public int glBufferAccess;
+  /** Controls the usage of the buffer data store:
+   * https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glBufferData.xhtml
+   * Supported options include STATIC_DRAW, DYNAMIC_DRAW, STREAM_DRAW, and STREAM_READ.
+   */
+  static public int bufferUsageRetained;
+  static public int bufferUsageImmediate;
+
+  /** Controls the access to the mapped buffer object's data store (when using buffer streaming).
+   * https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glMapBuffer.xhtml
+   * Supported options are READ_ONLY, WRITE_ONLY, and READ_WRITE.
+   */
+  static public int bufferMapAccess;
 
   // ........................................................
 

--- a/core/src/processing/opengl/PGraphicsOpenGL.java
+++ b/core/src/processing/opengl/PGraphicsOpenGL.java
@@ -575,14 +575,14 @@ public class PGraphicsOpenGL extends PGraphics {
 
     viewport = PGL.allocateIntBuffer(4);
 
-    PGL.glUsageRetained = PGL.DYNAMIC_DRAW;
-    PGL.glUsageImmediate = PGL.STATIC_DRAW;
-    PGL.glBufferAccess = PGL.READ_WRITE;
+    PGL.bufferUsageRetained = PGL.DYNAMIC_DRAW;
+    PGL.bufferUsageImmediate = PGL.STATIC_DRAW;
+    PGL.bufferMapAccess = PGL.READ_WRITE;
 
     polyAttribs = newAttributeMap();
     inGeo = newInGeometry(this, polyAttribs, IMMEDIATE);
     tessGeo = newTessGeometry(this, polyAttribs, IMMEDIATE,
-                              PGL.USE_BUFFER_OBJECT_STREAMING_IN_IMMEDIATE_MODE);
+                              PGL.bufferStreamingImmediate);
     texCache = newTexCache(this);
 
     projection = new PMatrix3D();
@@ -1239,46 +1239,46 @@ public class PGraphicsOpenGL extends PGraphics {
 
   protected void updatePolyBuffers(boolean lit, boolean tex,
                                    boolean needNormals, boolean needTexCoords) {
-    createPolyBuffers(PGL.glUsageImmediate);
+    createPolyBuffers(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyVertex.glId);
-    tessGeo.copyPolyVertices(PGL.glUsageImmediate);
+    tessGeo.copyPolyVertices(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyColor.glId);
-    tessGeo.copyPolyColors(PGL.glUsageImmediate);
+    tessGeo.copyPolyColors(PGL.bufferUsageImmediate);
 
     if (lit) {
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyAmbient.glId);
-      tessGeo.copyPolyAmbient(PGL.glUsageImmediate);
+      tessGeo.copyPolyAmbient(PGL.bufferUsageImmediate);
 
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolySpecular.glId);
-      tessGeo.copyPolySpecular(PGL.glUsageImmediate);
+      tessGeo.copyPolySpecular(PGL.bufferUsageImmediate);
 
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyEmissive.glId);
-      tessGeo.copyPolyEmissive(PGL.glUsageImmediate);
+      tessGeo.copyPolyEmissive(PGL.bufferUsageImmediate);
 
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyShininess.glId);
-      tessGeo.copyPolyShininess(PGL.glUsageImmediate);
+      tessGeo.copyPolyShininess(PGL.bufferUsageImmediate);
     }
 
     if (lit || needNormals) {
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyNormal.glId);
-      tessGeo.copyPolyNormals(PGL.glUsageImmediate);
+      tessGeo.copyPolyNormals(PGL.bufferUsageImmediate);
     }
 
     if (tex || needTexCoords) {
       pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyTexcoord.glId);
-      tessGeo.copyPolyTexCoords(PGL.glUsageImmediate);
+      tessGeo.copyPolyTexCoords(PGL.bufferUsageImmediate);
     }
 
     for (String name: polyAttribs.keySet()) {
       VertexAttribute attrib = polyAttribs.get(name);
       pgl.bindBuffer(PGL.ARRAY_BUFFER, attrib.buf.glId);
-      tessGeo.copyPolyAttribs(attrib, PGL.glUsageImmediate);
+      tessGeo.copyPolyAttribs(attrib, PGL.bufferUsageImmediate);
     }
 
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufPolyIndex.glId);
-    tessGeo.copyPolyIndices(PGL.glUsageImmediate);
+    tessGeo.copyPolyIndices(PGL.bufferUsageImmediate);
   }
 
 
@@ -1310,19 +1310,19 @@ public class PGraphicsOpenGL extends PGraphics {
 
 
   protected void updateLineBuffers() {
-    createLineBuffers(PGL.glUsageImmediate);
+    createLineBuffers(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineVertex.glId);
-    tessGeo.copyLineVertices(PGL.glUsageImmediate);
+    tessGeo.copyLineVertices(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineColor.glId);
-    tessGeo.copyLineColors(PGL.glUsageImmediate);
+    tessGeo.copyLineColors(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineAttrib.glId);
-    tessGeo.copyLineDirections(PGL.glUsageImmediate);
+    tessGeo.copyLineDirections(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufLineIndex.glId);
-    tessGeo.copyLineIndices(PGL.glUsageImmediate);
+    tessGeo.copyLineIndices(PGL.bufferUsageImmediate);
   }
 
 
@@ -1354,19 +1354,19 @@ public class PGraphicsOpenGL extends PGraphics {
 
 
   protected void updatePointBuffers() {
-    createPointBuffers(PGL.glUsageImmediate);
+    createPointBuffers(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointVertex.glId);
-    tessGeo.copyPointVertices(PGL.glUsageImmediate);
+    tessGeo.copyPointVertices(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointColor.glId);
-    tessGeo.copyPointColors(PGL.glUsageImmediate);
+    tessGeo.copyPointColors(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointAttrib.glId);
-    tessGeo.copyPointOffsets(PGL.glUsageImmediate);
+    tessGeo.copyPointOffsets(PGL.bufferUsageImmediate);
 
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufPointIndex.glId);
-    tessGeo.copyPointIndices(PGL.glUsageImmediate);
+    tessGeo.copyPointIndices(PGL.bufferUsageImmediate);
   }
 
 
@@ -2072,7 +2072,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
     VertexAttribute attrib = polyAttribs.get(name);
     if (attrib == null) {
-      attrib = new VertexAttribute(this, name, kind, type, size, PGL.glUsageImmediate);
+      attrib = new VertexAttribute(this, name, kind, type, size, PGL.bufferUsageImmediate);
       polyAttribs.put(name, attrib);
       inGeo.initAttrib(attrib);
       tessGeo.initAttrib(attrib);
@@ -9483,7 +9483,7 @@ public class PGraphicsOpenGL extends PGraphics {
     // Buffer mapping methods
 
     protected void mapPolyVerticesBuffer() {
-      polyVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      polyVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPolyVerticesBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9538,7 +9538,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyColorsBuffer() {
-      polyColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      polyColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initPolyColorsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9546,10 +9546,10 @@ public class PGraphicsOpenGL extends PGraphics {
       int sizei = polyVertexCount * PGL.SIZEOF_INT;
       if (bufObjStreaming) {
         if (onlymap) {
-          polyColorsBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyColorsBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
         } else {
           pgl.bufferData(PGL.ARRAY_BUFFER, sizei, null, usage);
-          polyColorsBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyColorsBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
           updatePolyColorsBuffer();
         }
         if (unmap) {
@@ -9593,7 +9593,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyNormalsBuffer() {
-      polyNormalsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      polyNormalsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPolyNormalsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9648,7 +9648,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyTexCoordsBuffer() {
-      polyTexCoordsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      polyTexCoordsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPolyTexCoordsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9703,7 +9703,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyAmbientBuffer() {
-      polyAmbientBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      polyAmbientBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initPolyAmbientBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9711,10 +9711,10 @@ public class PGraphicsOpenGL extends PGraphics {
       int sizei = polyVertexCount * PGL.SIZEOF_INT;
       if (bufObjStreaming) {
         if (onlymap) {
-          polyAmbientBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyAmbientBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
         } else {
           pgl.bufferData(PGL.ARRAY_BUFFER, sizei, null, usage);
-          polyAmbientBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyAmbientBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
           updatePolyAmbientBuffer();
         }
         if (unmap) {
@@ -9758,7 +9758,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolySpecularBuffer() {
-      polySpecularBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      polySpecularBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initPolySpecularBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9766,10 +9766,10 @@ public class PGraphicsOpenGL extends PGraphics {
       int sizei = polyVertexCount * PGL.SIZEOF_INT;
       if (bufObjStreaming) {
         if (onlymap) {
-          polySpecularBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polySpecularBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
         } else {
           pgl.bufferData(PGL.ARRAY_BUFFER, sizei, null, usage);
-          polySpecularBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polySpecularBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
           updatePolySpecularBuffer();
         }
         if (unmap) {
@@ -9813,7 +9813,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyEmissiveBuffer() {
-      polyEmissiveBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      polyEmissiveBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initPolyEmissiveBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9821,10 +9821,10 @@ public class PGraphicsOpenGL extends PGraphics {
       int sizei = polyVertexCount * PGL.SIZEOF_INT;
       if (bufObjStreaming) {
         if (onlymap) {
-          polyEmissiveBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyEmissiveBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
         } else {
           pgl.bufferData(PGL.ARRAY_BUFFER, sizei, null, usage);
-          polyEmissiveBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+          polyEmissiveBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
           updatePolyEmissiveBuffer();
         }
         if (unmap) {
@@ -9868,7 +9868,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyShininessBuffer() {
-      polyShininessBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      polyShininessBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPolyShininessBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -9876,10 +9876,10 @@ public class PGraphicsOpenGL extends PGraphics {
       int sizei = polyVertexCount * PGL.SIZEOF_FLOAT;
       if (bufObjStreaming) {
         if (onlymap) {
-          polyShininessBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+          polyShininessBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
         } else {
           pgl.bufferData(PGL.ARRAY_BUFFER, sizei, null, usage);
-          polyShininessBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+          polyShininessBuffer = pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
           updatePolyShininessBuffer();
         }
         if (unmap) {
@@ -9924,11 +9924,11 @@ public class PGraphicsOpenGL extends PGraphics {
 
     protected void mapPolyAttribBuffer(VertexAttribute attrib) {
       if (attrib.type == PGL.FLOAT) {
-        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer());
+        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer());
       } else if (attrib.type == PGL.INT) {
-        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer());
+        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer());
       } else if (attrib.type == PGL.BOOL) {
-        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess));
+        polyAttribBuffers.put(attrib.name, pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess));
       }
     }
 
@@ -9986,7 +9986,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPolyIndicesBuffer() {
-      polyIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.glBufferAccess).asShortBuffer();
+      polyIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.bufferMapAccess).asShortBuffer();
     }
 
     protected void initPolyIndicesBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10022,7 +10022,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapLineVerticesBuffer() {
-      lineVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      lineVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initLineVerticesBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10077,7 +10077,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapLineColorsBuffer() {
-      lineColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      lineColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initLineColorsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10132,7 +10132,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapLineDirectionsBuffer() {
-      lineDirectionsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      lineDirectionsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initLineDirectionsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10187,7 +10187,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapLineIndicesBuffer() {
-      lineIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.glBufferAccess).asShortBuffer();
+      lineIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.bufferMapAccess).asShortBuffer();
     }
 
     protected void initLineIndicesBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10223,7 +10223,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPointVerticesBuffer() {
-      pointVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      pointVerticesBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPointVerticesBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10278,7 +10278,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPointColorsBuffer() {
-      pointColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asIntBuffer();
+      pointColorsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asIntBuffer();
     }
 
     protected void initPointColorsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10333,7 +10333,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPointOffsetsBuffer() {
-      pointOffsetsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.glBufferAccess).asFloatBuffer();
+      pointOffsetsBuffer = pg.pgl.mapBuffer(PGL.ARRAY_BUFFER, PGL.bufferMapAccess).asFloatBuffer();
     }
 
     protected void initPointOffsetsBuffer(boolean onlymap, boolean unmap, int usage) {
@@ -10388,7 +10388,7 @@ public class PGraphicsOpenGL extends PGraphics {
     }
 
     protected void mapPointIndicesBuffer() {
-      pointIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.glBufferAccess).asShortBuffer();
+      pointIndicesBuffer = pg.pgl.mapBuffer(PGL.ELEMENT_ARRAY_BUFFER, PGL.bufferMapAccess).asShortBuffer();
     }
 
     protected void initPointIndicesBuffer(boolean onlymap, boolean unmap, int usage) {

--- a/core/src/processing/opengl/PShapeOpenGL.java
+++ b/core/src/processing/opengl/PShapeOpenGL.java
@@ -1182,7 +1182,7 @@ public class PShapeOpenGL extends PShape {
     }
     VertexAttribute attrib = polyAttribs.get(name);
     if (attrib == null) {
-      attrib = new VertexAttribute(pg, name, kind, type, size, PGL.glUsageRetained);
+      attrib = new VertexAttribute(pg, name, kind, type, size, PGL.bufferUsageRetained);
       polyAttribs.put(name, attrib);
       inGeo.initAttrib(attrib);
     }
@@ -3329,85 +3329,85 @@ public class PShapeOpenGL extends PShape {
       boolean createBuffer;
       if (root.tessKind == TRIANGLES && hasPolys) {
         createBuffer = bufPolyVertex == null;
-        if (createBuffer) bufPolyVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyVertex.glId);
-        tessGeo.initPolyVerticesBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyVerticesBuffer(!createBuffer, false, PGL.bufferUsageRetained);
         root.selVertices = tessGeo.polyVertices;
 
         createBuffer = bufPolyColor == null;
-        if (createBuffer) bufPolyColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyColor.glId);
-        tessGeo.initPolyColorsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyColorsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolyNormal == null;
-        if (createBuffer) bufPolyNormal = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyNormal = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyNormal.glId);
-        tessGeo.initPolyNormalsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyNormalsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolyTexCoord == null;
-        if (createBuffer) bufPolyTexCoord = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyTexCoord = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyTexCoord.glId);
-        tessGeo.initPolyTexCoordsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyTexCoordsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolyAmbient == null;
-        if (createBuffer) bufPolyAmbient = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyAmbient = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyAmbient.glId);
-        tessGeo.initPolyAmbientBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyAmbientBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolySpecular == null;
-        if (createBuffer) bufPolySpecular = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufPolySpecular = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolySpecular.glId);
-        tessGeo.initPolySpecularBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolySpecularBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolyEmissive == null;
-        if (createBuffer) bufPolyEmissive = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyEmissive = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyEmissive.glId);
-        tessGeo.initPolyEmissiveBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyEmissiveBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPolyShininess == null;
-        if (createBuffer) bufPolyShininess = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPolyShininess = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyShininess.glId);
-        tessGeo.initPolyShininessBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPolyShininessBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         for (String name: polyAttribs.keySet()) {
           VertexAttribute attrib = polyAttribs.get(name);
           createBuffer = !attrib.bufferCreated();
           if (createBuffer) attrib.createBuffer(pgl);
           pgl.bindBuffer(PGL.ARRAY_BUFFER, attrib.buf.glId);
-          tessGeo.initPolyAttribsBuffer(attrib, !createBuffer, false, PGL.glUsageRetained);
+          tessGeo.initPolyAttribsBuffer(attrib, !createBuffer, false, PGL.bufferUsageRetained);
         }
       } else if (root.tessKind == LINES && hasLines) {
         createBuffer = bufLineVertex == null;
-        if (createBuffer) bufLineVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufLineVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineVertex.glId);
-        tessGeo.initLineVerticesBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initLineVerticesBuffer(!createBuffer, false, PGL.bufferUsageRetained);
         root.selVertices = tessGeo.lineVertices;
 
         createBuffer = bufLineColor == null;
-        if (createBuffer) bufLineColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufLineColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineColor.glId);
-        tessGeo.initLineColorsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initLineColorsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufLineAttrib == null;
-        if (createBuffer) bufLineAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufLineAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineAttrib.glId);
-        tessGeo.initLineDirectionsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initLineDirectionsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
       } else if (root.tessKind == POINTS && hasPoints) {
         createBuffer = bufPointVertex == null;
-        if (createBuffer) bufPointVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPointVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointVertex.glId);
-        tessGeo.initPointVerticesBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPointVerticesBuffer(!createBuffer, false, PGL.bufferUsageRetained);
         root.selVertices = tessGeo.pointVertices;
 
         createBuffer = bufPointColor == null;
-        if (createBuffer) bufPointColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+        if (createBuffer) bufPointColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointColor.glId);
-        tessGeo.initPointColorsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPointColorsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
 
         createBuffer = bufPointAttrib == null;
-        if (createBuffer) bufPointAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+        if (createBuffer) bufPointAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
         pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointAttrib.glId);
-        tessGeo.initPointOffsetsBuffer(!createBuffer, false, PGL.glUsageRetained);
+        tessGeo.initPointOffsetsBuffer(!createBuffer, false, PGL.bufferUsageRetained);
       }
 
       pgl.bindBuffer(PGL.ARRAY_BUFFER, 0);
@@ -3593,7 +3593,7 @@ public class PShapeOpenGL extends PShape {
 
       if (tessGeo == null) {
         tessGeo = PGraphicsOpenGL.newTessGeometry(pg, polyAttribs, PGraphicsOpenGL.RETAINED,
-                                                  PGL.USE_BUFFER_OBJECT_STREAMING_IN_RETAINED_MODE);
+                                                  PGL.bufferStreamingRetained);
       }
       tessGeo.clear();
 
@@ -4620,110 +4620,110 @@ public class PShapeOpenGL extends PShape {
 
   protected void initPolyBuffers() {
     boolean createBuffer = bufPolyVertex == null;
-    if (createBuffer) bufPolyVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyVertex.glId);
-    tessGeo.initPolyVerticesBuffer(false, true, PGL.glUsageRetained);
+    tessGeo.initPolyVerticesBuffer(false, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyColor == null;
-    if (createBuffer) bufPolyColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyColor.glId);
-    tessGeo.initPolyColorsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyColorsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyNormal == null;
-    if (createBuffer) bufPolyNormal = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyNormal = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 3, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyNormal.glId);
-    tessGeo.initPolyNormalsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyNormalsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyTexCoord == null;
-    if (createBuffer) bufPolyTexCoord = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyTexCoord = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyTexCoord.glId);
-    tessGeo.initPolyTexCoordsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyTexCoordsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyAmbient == null;
-    if (createBuffer) bufPolyAmbient = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyAmbient = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyAmbient.glId);
-    tessGeo.initPolyAmbientBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyAmbientBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolySpecular == null;
-    if (createBuffer) bufPolySpecular = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufPolySpecular = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolySpecular.glId);
-    tessGeo.initPolySpecularBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolySpecularBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyEmissive == null;
-    if (createBuffer) bufPolyEmissive = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyEmissive = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyEmissive.glId);
-    tessGeo.initPolyEmissiveBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyEmissiveBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPolyShininess == null;
-    if (createBuffer) bufPolyShininess = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPolyShininess = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPolyShininess.glId);
-    tessGeo.initPolyShininessBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyShininessBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     for (String name: polyAttribs.keySet()) {
       VertexAttribute attrib = polyAttribs.get(name);
       createBuffer = !attrib.bufferCreated();
       if (createBuffer) attrib.createBuffer(pgl);
       pgl.bindBuffer(PGL.ARRAY_BUFFER, attrib.buf.glId);
-      tessGeo.initPolyAttribsBuffer(attrib, !createBuffer, true, PGL.glUsageRetained);
+      tessGeo.initPolyAttribsBuffer(attrib, !createBuffer, true, PGL.bufferUsageRetained);
     }
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, 0);
 
     createBuffer = bufPolyIndex == null;
-    if (createBuffer) bufPolyIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.glUsageRetained, true);
+    if (createBuffer) bufPolyIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.bufferUsageRetained, true);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufPolyIndex.glId);
-    tessGeo.initPolyIndicesBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPolyIndicesBuffer(!createBuffer, true, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, 0);
   }
 
   protected void initLineBuffers() {
     boolean createBuffer = bufLineVertex == null;
-    if (createBuffer) bufLineVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufLineVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineVertex.glId);
-    tessGeo.initLineVerticesBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initLineVerticesBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufLineColor == null;
-    if (createBuffer) bufLineColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufLineColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineColor.glId);
-    tessGeo.initLineColorsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initLineColorsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufLineAttrib == null;
-    if (createBuffer) bufLineAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufLineAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufLineAttrib.glId);
-    tessGeo.initLineDirectionsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initLineDirectionsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, 0);
 
     createBuffer = bufLineIndex == null;
-    if (createBuffer) bufLineIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.glUsageRetained, true);
+    if (createBuffer) bufLineIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.bufferUsageRetained, true);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufLineIndex.glId);
-    tessGeo.initLineIndicesBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initLineIndicesBuffer(!createBuffer, true, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, 0);
   }
 
 
   protected void initPointBuffers() {
     boolean createBuffer = bufPointVertex == null;
-    if (createBuffer) bufPointVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPointVertex = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 4, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointVertex.glId);
-    tessGeo.initPointVerticesBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPointVerticesBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPointColor == null;
-    if (createBuffer) bufPointColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.glUsageRetained);
+    if (createBuffer) bufPointColor = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 1, PGL.SIZEOF_INT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointColor.glId);
-    tessGeo.initPointColorsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPointColorsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     createBuffer = bufPointAttrib == null;
-    if (createBuffer) bufPointAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.glUsageRetained);
+    if (createBuffer) bufPointAttrib = new VertexBuffer(pg, PGL.ARRAY_BUFFER, 2, PGL.SIZEOF_FLOAT, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ARRAY_BUFFER, bufPointAttrib.glId);
-    tessGeo.initPointOffsetsBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPointOffsetsBuffer(!createBuffer, true, PGL.bufferUsageRetained);
 
     pgl.bindBuffer(PGL.ARRAY_BUFFER, 0);
 
     createBuffer = bufPointIndex == null;
-    if (createBuffer) bufPointIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.glUsageRetained, true);
+    if (createBuffer) bufPointIndex = new VertexBuffer(pg, PGL.ELEMENT_ARRAY_BUFFER, 1, PGL.SIZEOF_INDEX, PGL.bufferUsageRetained, true);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, bufPointIndex.glId);
-    tessGeo.initPointIndicesBuffer(!createBuffer, true, PGL.glUsageRetained);
+    tessGeo.initPointIndicesBuffer(!createBuffer, true, PGL.bufferUsageRetained);
     pgl.bindBuffer(PGL.ELEMENT_ARRAY_BUFFER, 0);
   }
 


### PR DESCRIPTION
Consider this PR to make the name of these parameters more consistent. We might need to play with them until a optimal configuration is found (moment in which we can set them as protected) or perhaps they have to left public for advanced users to tweak these settings depending on the platform or usage mode. Not sure at this point if there is one configuration that fits all situations in terms of performance.