### PR TITLE
Fix IDE auto-formatting confused by method references (40b1) #279

### DIFF
--- a/java/src/processing/mode/java/AutoFormat.java
+++ b/java/src/processing/mode/java/AutoFormat.java
@@ -732,7 +732,7 @@ public class AutoFormat implements Formatter {
       case ':':
         // Java 8 :: operator.
         if (peek() == ':') {
-          result.append(c).append(nextChar());
+          buf.append(c).append(nextChar());
           break;
         }
 


### PR DESCRIPTION
This text is an automatic translation.

The build at hand is working correctly with this change.

I am not familiar with java and do not know how to run tests.
I have not been able to verify the test.