### PR TITLE
Fix Some keys can't be entered on the On-Screen Keyboard #403

### DIFF
--- a/app/src/processing/app/syntax/DefaultInputHandler.java
+++ b/app/src/processing/app/syntax/DefaultInputHandler.java
@@ -131,6 +131,12 @@ public class DefaultInputHandler extends InputHandler {
     int keyCode = evt.getKeyCode();
     int modifiers = evt.getModifiersEx();
 
+    // Remove mouse button down masks that get mixed in with KeyEvent.
+    // https://github.com/processing/processing4/issues/403
+    modifiers &= ~(InputEvent.BUTTON1_DOWN_MASK |
+      InputEvent.BUTTON2_DOWN_MASK |
+      InputEvent.BUTTON3_DOWN_MASK);
+
     // moved this earlier so it doesn't get random meta clicks
     if (keyCode == KeyEvent.VK_CONTROL ||
         keyCode == KeyEvent.VK_SHIFT ||


### PR DESCRIPTION
Fix Some keys can't be entered on the On-Screen Keyboard #403

Perhaps it would be more correct to check the number of buttons as in Issue.
But for most users, this would be a useless process.

Therefore, we decided to remove up to `BUTTON3_DOWN_MASK`, which has a constant.
This is simple and high performance.