### PR TITLE
Fix parsing of java error messages containing ":"

### DIFF
--- a/java/src/processing/mode/java/Compiler.java
+++ b/java/src/processing/mode/java/Compiler.java
@@ -133,7 +133,7 @@ public class Compiler {
 
         // get first line, which contains file name, line number,
         // and at least the first line of the error message
-        String errorFormat = "([\\w\\d_]+.java):(\\d+):\\s*(.*):\\s*(.*)\\s*";
+        String errorFormat = "([\\w\\d_]+\\.java):(\\d+):\\s*([^:]*):\\s*(.*)\\s*";
         String[] pieces = PApplet.match(line, errorFormat);
         //PApplet.println(pieces);
 


### PR DESCRIPTION
Fixes #492, allowing a message like `The local variable noise may not have been initialized. Note that a problem regarding missing 'default:' on 'switch' has been suppressed, which is perhaps related to this problem` to be printed correctly.