### PR TITLE
(Docs) Fix unclosed <b> tag in noSmooth()

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -1192,7 +1192,7 @@ public class PApplet implements PConstants {
    * edges and images with hard edges between the pixels
    * when enlarged rather than interpolating pixels. Note
    * that <b>smooth()</b> is active by default, so it is necessary
-   * to call <b>noSmooth()<b> to disable smoothing of geometry,
+   * to call <b>noSmooth()</b> to disable smoothing of geometry,
    * fonts, and images. Since the release of Processing 3.0,
    * the <b>noSmooth()</b> function can only be run once for each
    * sketch, either at the top of a sketch without a <b>setup()</b>,


### PR DESCRIPTION
Moved here from [a PR on processing-website](https://github.com/processing/processing-website/pull/300) to ensure the change is more permanent.