### PR TITLE
Resolving ant run

### DIFF
--- a/build/windows/config.xml
+++ b/build/windows/config.xml
@@ -23,6 +23,7 @@
     <cp>lib/jna-platform.jar</cp>
     <cp>lib/ant.jar</cp>
     <cp>lib/ant-launcher.jar</cp>
+    <cp>lib/flatlaf.jar</cp>
 
     <!-- <cp>%EXEDIR%/java/lib/tools.jar</cp> -->
 


### PR DESCRIPTION
The splash screen does not move forward towards the base class. The issue arises at runtime. Including flatlaf.jar as a classpath worked for me.

Steps to reproduce and resolve-

- clone repo

- `ant run` inside the build folder

- The splash screen does not move forward.

- close the splash window and open task manager on windows.

- Right Click on OpenJDK Platform Binary -> End Task(otherwise ant shows an error due to some resource locking by java binary)

- add <cp>lib/flatlaf.jar</cp> under classpath tag of `windows/config.xml`

- execute `ant run` again. (worked for me).

Linking a related issue #485 