### PR TITLE
Fix --full-screen option from export window

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -10277,6 +10277,7 @@ public class PApplet implements PConstants {
 
     int displayNum = -1;  // use default
     boolean present = false;
+    boolean fullScreen = false;
     float uiScale = 0;
 
     String param, value;
@@ -10342,6 +10343,9 @@ public class PApplet implements PConstants {
 
         } else if (args[argIndex].equals(ARGS_EXTERNAL)) {
           external = true;
+
+        } else if (args[argIndex].equals(ARGS_FULL_SCREEN)) {
+          fullScreen = true;
 
         } else {
           name = args[argIndex];
@@ -10418,6 +10422,7 @@ public class PApplet implements PConstants {
     sketch.display = displayNum;
 
     sketch.present = present;
+    sketch.fullScreen = fullScreen;
 
     // For 3.0.1, moved this above handleSettings() so that loadImage() can be
     // used inside settings(). Sets a terrible precedent, but the alternative

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -1227,21 +1227,29 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
     footerWriter.addCodeLine(indent1 + "static public void main(String[] passedArgs) {");
     footerWriter.addCode(indent2 +   "String[] appletArgs = new String[] { ");
 
+
+
     { // assemble line with applet args
-      if (Preferences.getBoolean("export.application.fullscreen")) {
-        footerWriter.addCode("\"" + PApplet.ARGS_FULL_SCREEN + "\", ");
+      StringJoiner argsJoiner = new StringJoiner(", ");
+
+      boolean shouldFullScreen = Preferences.getBoolean("export.application.present");
+      shouldFullScreen = shouldFullScreen || Preferences.getBoolean("export.application.fullscreen");
+      if (shouldFullScreen) {
+        argsJoiner.add("\"" + PApplet.ARGS_FULL_SCREEN + "\"");
 
         String bgColor = Preferences.get("run.present.bgcolor");
-        footerWriter.addCode("\"" + PApplet.ARGS_BGCOLOR + "=" + bgColor + "\", ");
+        argsJoiner.add("\"" + PApplet.ARGS_BGCOLOR + "=" + bgColor + "\"");
 
         if (Preferences.getBoolean("export.application.stop")) {
           String stopColor = Preferences.get("run.present.stop.color");
-          footerWriter.addCode("\"" + PApplet.ARGS_STOP_COLOR + "=" + stopColor + "\", ");
+          argsJoiner.add("\"" + PApplet.ARGS_STOP_COLOR + "=" + stopColor + "\"");
         } else {
-          footerWriter.addCode("\"" + PApplet.ARGS_HIDE_STOP + "\", ");
+          argsJoiner.add("\"" + PApplet.ARGS_HIDE_STOP + "\"");
         }
       }
-      footerWriter.addCode("\"" + sketchName + "\"");
+      
+      argsJoiner.add("\"" + sketchName + "\"");
+      footerWriter.addCode(argsJoiner.toString());
     }
 
     footerWriter.addCodeLine(" };");

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -11,8 +11,10 @@ import java.io.IOException;
 import java.util.Optional;
 
 import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
+import processing.app.Preferences;
 import processing.app.SketchException;
 import processing.mode.java.preproc.PreprocessorResult;
 import processing.mode.java.preproc.PdePreprocessIssueException;
@@ -23,6 +25,11 @@ public class ParserTests {
   @BeforeClass
   public static void init() {
     ProcessingTestUtil.init();
+  }
+
+  @Before
+  public void before() {
+    Preferences.setBoolean("export.application.fullscreen", false);
   }
 
   static void expectRecognitionException(final String id,
@@ -432,7 +439,8 @@ public class ParserTests {
 
   @Test
   public void testMultiMultilineString() {
-    expectGood("multimultilinestr");
+    Preferences.setBoolean("export.application.fullscreen", true);
+    expectGood("fullscreen_export");
   }
 
 }

--- a/java/test/resources/fullscreen_export.expected
+++ b/java/test/resources/fullscreen_export.expected
@@ -1,0 +1,39 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class fullscreen_export extends PApplet {
+
+int x = 0;
+
+ public void setup() {
+  background(0);
+  noStroke();
+  fill(102);
+}
+
+ public void draw() {
+  rect(x, height*0.2f, 1, height*0.6f);
+  x = x + 2;
+}
+
+
+    static public void main(String[] passedArgs) {
+        String[] appletArgs = new String[] { "--full-screen", "--bgcolor=null", "--hide-stop", "fullscreen_export" };
+        if (passedArgs != null) {
+            PApplet.main(concat(appletArgs, passedArgs));
+        } else {
+            PApplet.main(appletArgs);
+        }
+    }
+}

--- a/java/test/resources/fullscreen_export.pde
+++ b/java/test/resources/fullscreen_export.pde
@@ -1,0 +1,12 @@
+int x = 0;
+
+void setup() {
+  background(0);
+  noStroke();
+  fill(102);
+}
+
+void draw() {
+  rect(x, height*0.2, 1, height*0.6);
+  x = x + 2;
+}


### PR DESCRIPTION
Fixes #488. Clean up the footer writer section of the preprocessor for easier reading but also fix adding and looking for --full-screen which appears to have been left off at some point. Specifically:

 - Though not the source of the issue, the footer writer section of the `PdeParseTreeListener` was a little hard to read so cleaned up that code slightly.
 - Found the issue with the handling of --full-screen which required a change in `PApplet`
 - Added tests for the full screen export option for the parser / preprocessing