### PR TITLE
java/preproc: Use class lookup to get the sketchname instead of hardcoding it

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -1225,9 +1225,8 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
     footerWriter.addEmptyLine();
     footerWriter.addCodeLine(indent1 + "static public void main(String[] passedArgs) {");
-    footerWriter.addCode(indent2 +   "String[] appletArgs = new String[] { ");
-
-
+    footerWriter.addCodeLine(indent2 + "String sketchName = MethodHandles.lookup().lookupClass().getName();");
+    footerWriter.addCode(indent2 + "String[] appletArgs = new String[] { ");
 
     { // assemble line with applet args
       StringJoiner argsJoiner = new StringJoiner(", ");
@@ -1248,7 +1247,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
         }
       }
       
-      argsJoiner.add("\"" + sketchName + "\"");
+      argsJoiner.add("sketchName");
       footerWriter.addCode(argsJoiner.toString());
     }
 

--- a/java/test/resources/annotations.expected
+++ b/java/test/resources/annotations.expected
@@ -47,7 +47,8 @@ class Pear {}
     public void settings() { size(200,200); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "annotations" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1064.expected
+++ b/java/test/resources/bug1064.expected
@@ -20,7 +20,8 @@ public class bug1064 extends PApplet {
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1064" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug136.expected
+++ b/java/test/resources/bug136.expected
@@ -35,7 +35,8 @@ alist.get(0);
     public void settings() { size(400,200); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug136" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1362.expected
+++ b/java/test/resources/bug1362.expected
@@ -20,7 +20,8 @@ if (true) {} else { new String(); }
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1362" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1390.expected
+++ b/java/test/resources/bug1390.expected
@@ -47,7 +47,8 @@ public void setup() {
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1390" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1442.expected
+++ b/java/test/resources/bug1442.expected
@@ -19,7 +19,8 @@ public float a() {
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1442" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1511.expected
+++ b/java/test/resources/bug1511.expected
@@ -28,7 +28,8 @@ public class bug1511 extends PApplet {
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1511" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1512.expected
+++ b/java/test/resources/bug1512.expected
@@ -20,7 +20,8 @@ println("oi/*");
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1512" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1514a.expected
+++ b/java/test/resources/bug1514a.expected
@@ -26,7 +26,8 @@ public class bug1514a extends PApplet {
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1514a" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1514b.expected
+++ b/java/test/resources/bug1514b.expected
@@ -26,7 +26,8 @@ public class bug1514b extends PApplet {
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1514b" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1515.expected
+++ b/java/test/resources/bug1515.expected
@@ -23,7 +23,8 @@ public <T extends PApplet> void doSomething( T thing ){
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1515" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1516.expected
+++ b/java/test/resources/bug1516.expected
@@ -43,7 +43,8 @@ Collections.sort(list, comparator);
 } 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1516" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1517.expected
+++ b/java/test/resources/bug1517.expected
@@ -43,7 +43,8 @@ Collections.sort(list, comparator);
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1517" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1518a.expected
+++ b/java/test/resources/bug1518a.expected
@@ -37,7 +37,8 @@ return 0;
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1518a" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1518b.expected
+++ b/java/test/resources/bug1518b.expected
@@ -35,7 +35,8 @@ return 0;
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1518b" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1525.expected
+++ b/java/test/resources/bug1525.expected
@@ -22,7 +22,8 @@ if (frameCount > (frameRate - 1)) {
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1525" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1534.expected
+++ b/java/test/resources/bug1534.expected
@@ -20,7 +20,8 @@ char c = '\"';
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1534" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug1936.expected
+++ b/java/test/resources/bug1936.expected
@@ -20,7 +20,8 @@ char a = PApplet.parseChar(PApplet.parseByte(PApplet.parseInt("15")));
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug1936" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug281.expected
+++ b/java/test/resources/bug281.expected
@@ -23,7 +23,8 @@ if ( "monopoly".charAt( 3 ) == '(' )
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug281" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug315g.expected
+++ b/java/test/resources/bug315g.expected
@@ -29,7 +29,8 @@ ellipse(75, y, d, d);
 smooth();}
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug315g" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug4.expected
+++ b/java/test/resources/bug4.expected
@@ -25,7 +25,8 @@ float u = (PApplet.parseFloat(x)/width);
     public void settings() { size(100,100); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug4" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug400g.expected
+++ b/java/test/resources/bug400g.expected
@@ -25,7 +25,8 @@ public void setup(){
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug400g" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug427g.expected
+++ b/java/test/resources/bug427g.expected
@@ -27,7 +27,8 @@ public class MyClass {
 }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug427g" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug481.expected
+++ b/java/test/resources/bug481.expected
@@ -23,7 +23,8 @@ Class[] abc = new Class[]{Applet.class};
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug481" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug598.expected
+++ b/java/test/resources/bug598.expected
@@ -52,7 +52,8 @@ public class bug598 extends PApplet {
   }
 
   static public void main(String[] passedArgs) {
-      String[] appletArgs = new String[] { "bug598" };
+      String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
       if (passedArgs != null) {
           PApplet.main(concat(appletArgs, passedArgs));
       } else {

--- a/java/test/resources/bug5a.expected
+++ b/java/test/resources/bug5a.expected
@@ -21,7 +21,8 @@ println("The next line should not cause a failure.");
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug5a" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug5b.expected
+++ b/java/test/resources/bug5b.expected
@@ -21,7 +21,8 @@ println("The next line should not cause a failure.");
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug5b" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/bug631.expected
+++ b/java/test/resources/bug631.expected
@@ -26,7 +26,8 @@ firstLoop:
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "bug631" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/charspecial.expected
+++ b/java/test/resources/charspecial.expected
@@ -22,7 +22,8 @@ println(x);
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "charspecial" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/classinstatic.expected
+++ b/java/test/resources/classinstatic.expected
@@ -31,7 +31,8 @@ println(t.toString());
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "classinstatic" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/color.expected
+++ b/java/test/resources/color.expected
@@ -22,7 +22,8 @@ int c2 = test ? 0xFFA011CD : 0xC0C0C0C0;
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "color" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/colorimport.expected
+++ b/java/test/resources/colorimport.expected
@@ -27,7 +27,8 @@ int c2 = test ? 0xFFA011CD : 0xC0C0C0C0;
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "colorimport" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/colorreturn.expected
+++ b/java/test/resources/colorreturn.expected
@@ -33,7 +33,8 @@ public void draw() {
     public void settings() { size(100,100); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "colorreturn" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/fullscreen.expected
+++ b/java/test/resources/fullscreen.expected
@@ -23,7 +23,8 @@ public class fullscreen extends PApplet {
     public void settings() { fullScreen(FX2D); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "fullscreen" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/fullscreen_arg.expected
+++ b/java/test/resources/fullscreen_arg.expected
@@ -23,7 +23,8 @@ public class fullscreen_arg extends PApplet {
     public void settings() { fullScreen(FX2D, 2); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "fullscreen_arg" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/fullscreen_export.expected
+++ b/java/test/resources/fullscreen_export.expected
@@ -29,7 +29,8 @@ int x = 0;
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "--full-screen", "--bgcolor=null", "--hide-stop", "fullscreen_export" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { "--full-screen", "--bgcolor=null", "--hide-stop", sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/fullscreen_noarg.expected
+++ b/java/test/resources/fullscreen_noarg.expected
@@ -23,7 +23,8 @@ public class fullscreen_noarg extends PApplet {
     public void settings() { fullScreen(); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "fullscreen_noarg" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/generics.expected
+++ b/java/test/resources/generics.expected
@@ -21,7 +21,8 @@ List<String> test = new ArrayList<>();
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "generics" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/lambdaexample.expected
+++ b/java/test/resources/lambdaexample.expected
@@ -24,7 +24,8 @@ test.forEach((x) -> { println(x); });
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "lambdaexample" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/multilinestr.expected
+++ b/java/test/resources/multilinestr.expected
@@ -25,7 +25,8 @@ println(testMultiline);
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "multilinestr" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/multilinestrclass.expected
+++ b/java/test/resources/multilinestrclass.expected
@@ -33,7 +33,8 @@ class TestClass {
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "multilinestrclass" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/multimultilinestr.expected
+++ b/java/test/resources/multimultilinestr.expected
@@ -25,7 +25,8 @@ println(testMultiline2);
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "multimultilinestr" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { "--full-screen", "--bgcolor=null", "--hide-stop", sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/nosmooth.expected
+++ b/java/test/resources/nosmooth.expected
@@ -32,7 +32,8 @@ public class nosmooth extends PApplet {
 noSmooth(); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "nosmooth" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/packageTest.expected
+++ b/java/test/resources/packageTest.expected
@@ -23,7 +23,8 @@ List<String> test = new ArrayList<>();
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "packageTest" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/parampixeldensity.expected
+++ b/java/test/resources/parampixeldensity.expected
@@ -33,7 +33,8 @@ public class parampixeldensity extends PApplet {
   }
 
   static public void main(String[] passedArgs) {
-      String[] appletArgs = new String[] { "parampixeldensity" };
+      String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
       if (passedArgs != null) {
           PApplet.main(concat(appletArgs, passedArgs));
       } else {

--- a/java/test/resources/pdfwrite.expected
+++ b/java/test/resources/pdfwrite.expected
@@ -35,7 +35,8 @@ public class pdfwrite extends PApplet {
     public void settings() { size(400,400,PDF,"filename.pdf"); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "pdfwrite" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/pgraphics.expected
+++ b/java/test/resources/pgraphics.expected
@@ -27,7 +27,8 @@ PGraphics gfx;
 
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "pgraphics" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/sizeclass.expected
+++ b/java/test/resources/sizeclass.expected
@@ -40,7 +40,8 @@ class Truc {
     public void settings() { size(200, 200); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "sizeclass" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/sizethis.expected
+++ b/java/test/resources/sizethis.expected
@@ -35,7 +35,8 @@ public class sizethis extends PApplet {
     public void settings() { size(400,400,PDF,"filename.pdf"); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "sizethis" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/smoothnoparam.expected
+++ b/java/test/resources/smoothnoparam.expected
@@ -32,7 +32,8 @@ public class smoothnoparam extends PApplet {
 smooth(); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "smoothnoparam" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/smoothnoparamthis.expected
+++ b/java/test/resources/smoothnoparamthis.expected
@@ -32,7 +32,8 @@ public class smoothnoparamthis extends PApplet {
 smooth(); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "smoothnoparamthis" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/smoothparam.expected
+++ b/java/test/resources/smoothparam.expected
@@ -32,7 +32,8 @@ public class smoothparam extends PApplet {
 smooth(4); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "smoothparam" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/smoothparamstatic.expected
+++ b/java/test/resources/smoothparamstatic.expected
@@ -30,7 +30,8 @@ ellipse(150,150,100,100);
 smooth(4); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "smoothparamstatic" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/specialmethodsprivate.expected
+++ b/java/test/resources/specialmethodsprivate.expected
@@ -32,7 +32,8 @@ class Test {
     public void settings() { size(100,100); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "specialmethodsprivate" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/speicalmethods.expected
+++ b/java/test/resources/speicalmethods.expected
@@ -37,7 +37,8 @@ public void mousePressed() {
     public void settings() { size(100,100); }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "speicalmethods" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/staticpixeldensity.expected
+++ b/java/test/resources/staticpixeldensity.expected
@@ -31,7 +31,8 @@ ellipse(70, 48, 36, 36);
     }
 
     static public void main(String[] passedArgs) {
-        String[] appletArgs = new String[] { "staticpixeldensity" };
+        String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
         if (passedArgs != null) {
             PApplet.main(concat(appletArgs, passedArgs));
         } else {

--- a/java/test/resources/typeinference.expected
+++ b/java/test/resources/typeinference.expected
@@ -34,7 +34,8 @@ public class typeinference extends PApplet {
 
 
   static public void main(String[] passedArgs) {
-    String[] appletArgs = new String[] { "typeinference" };
+    String sketchName = MethodHandles.lookup().lookupClass().getName();
+        String[] appletArgs = new String[] { sketchName };
     if (passedArgs != null) {
       PApplet.main(concat(appletArgs, passedArgs));
     } else {


### PR DESCRIPTION
So far the sketchname was passed to the PApplet hardcoded as string in the generated
Java. While this approach is absolutely fine it is duplicate information.
For those who directly edit on the java lever (e.g. to get proper IDE support)
this means two points of edit when changing the sketch name.

Outside of the processing IDE there is no understanding of a sketch name only
a project name with a main class.

We therefore propose that the main class should be used as only source of truth
and the PApplet sketch name should be derived from it.
This also allows to extend the main class for multiple binaries from the same source.

Signed-off-by: Mimoja <git@mimoja.de>