### PR TITLE
Static with class definition fix.

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -86,6 +86,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
   private boolean sizeIsFullscreen = false;
   private boolean noSmoothRequiresRewrite = false;
   private boolean smoothRequiresRewrite = false;
+  private boolean userImportingManually = false;
   private RewriteResult headerResult;
   private RewriteResult footerResult;
 
@@ -443,6 +444,10 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
     foundImports.add(ImportStatement.parse(importStringNoSemi));
 
+    if (importStringNoSemi.startsWith("processing.core.")) {
+      userImportingManually = true;
+    }
+
     delete(ctx.start, ctx.stop);
   }
 
@@ -498,7 +503,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
    * @param ctx ANTLR context for the sketch.
    */
   public void exitStaticProcessingSketch(ProcessingParser.StaticProcessingSketchContext ctx) {
-    mode = Mode.STATIC;
+    mode = foundMain ? Mode.JAVA : Mode.STATIC;
   }
 
   /**
@@ -1072,10 +1077,16 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
   protected void writeImports(PrintWriterWithEditGen headerWriter,
         RewriteResultBuilder resultBuilder) {
 
-    writeImportList(headerWriter, coreImports, resultBuilder);
+    if (!userImportingManually) {
+      writeImportList(headerWriter, coreImports, resultBuilder);
+    }
+
     writeImportList(headerWriter, codeFolderImports, resultBuilder);
     writeImportList(headerWriter, foundImports, resultBuilder);
-    writeImportList(headerWriter, defaultImports, resultBuilder);
+
+    if (!userImportingManually) {
+      writeImportList(headerWriter, defaultImports, resultBuilder);
+    }
   }
 
   /**

--- a/java/src/processing/mode/java/preproc/Processing.g4
+++ b/java/src/processing/mode/java/preproc/Processing.g4
@@ -20,8 +20,8 @@ import JavaParser;
 
 // main entry point, select sketch type
 processingSketch
-    : javaProcessingSketch
-    | staticProcessingSketch
+    : staticProcessingSketch
+    | javaProcessingSketch
     | activeProcessingSketch
 //    | warnMixedModes
     ;
@@ -33,7 +33,7 @@ javaProcessingSketch
 
 // No method declarations, just statements
 staticProcessingSketch
-    : (importDeclaration | blockStatement)* EOF
+    : (importDeclaration | blockStatement | typeDeclaration)* EOF
     ;
 
 // active mode, has function definitions

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -443,4 +443,9 @@ public class ParserTests {
     expectGood("fullscreen_export");
   }
 
+  @Test
+  public void testStaticClass() {
+    expectGood("staticclass");
+  }
+
 }

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -448,4 +448,9 @@ public class ParserTests {
     expectGood("staticclass");
   }
 
+  @Test
+  public void testCustomRootClass() {
+    expectGood("customrootclass");
+  }
+
 }

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -419,7 +419,7 @@ public class ParserTests {
 
   @Test
   public void testMixing() {
-    expectRunnerException("mixing", 1);
+    expectRunnerException("mixing", 6);
   }
 
   @Test

--- a/java/test/processing/mode/java/ProblemFactoryTest.java
+++ b/java/test/processing/mode/java/ProblemFactoryTest.java
@@ -15,7 +15,7 @@ public class ProblemFactoryTest {
 
   private PdePreprocessIssue pdePreprocessIssue;
   private List<Integer> tabStarts;
-  private Editor editor;
+
   private List<Integer> starts;
 
   @Before
@@ -25,24 +25,10 @@ public class ProblemFactoryTest {
     tabStarts = new ArrayList<>();
     tabStarts.add(5);
 
-    editor = Mockito.mock(Editor.class);
-    Mockito.when(editor.getLineStartOffset(3)).thenReturn(10);
-    Mockito.when(editor.getLineStopOffset(3)).thenReturn(12);
-
     starts = new ArrayList<>();
     starts.add(0);
     starts.add(5);
     starts.add(10);
-  }
-
-  @Test
-  public void buildWithEditor() {
-    Problem problem = ProblemFactory.build(pdePreprocessIssue, tabStarts, 15, editor);
-
-    Assert.assertEquals(3, problem.getLineNumber());
-    Assert.assertEquals("test", problem.getMessage());
-    Assert.assertEquals(10, problem.getStartOffset());
-    Assert.assertEquals(11, problem.getStopOffset());
   }
 
   @Test

--- a/java/test/resources/customrootclass.expected
+++ b/java/test/resources/customrootclass.expected
@@ -1,0 +1,23 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class CustomObj extends PApplet {
+
+public static void main(String[] argv) {
+
+    System.out.println("here");
+
+}
+
+}

--- a/java/test/resources/customrootclass.pde
+++ b/java/test/resources/customrootclass.pde
@@ -1,0 +1,23 @@
+import processing.core.*;
+import processing.data.*;
+import processing.event.*;
+import processing.opengl.*;
+
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.io.File;
+import java.io.BufferedReader;
+import java.io.PrintWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.IOException;
+
+public class CustomObj extends PApplet {
+
+public static void main(String[] argv) {
+
+    System.out.println("here");
+
+}
+
+}

--- a/java/test/resources/staticclass.expected
+++ b/java/test/resources/staticclass.expected
@@ -1,0 +1,47 @@
+import processing.core.*; 
+import processing.data.*; 
+import processing.event.*; 
+import processing.opengl.*; 
+
+import java.util.HashMap; 
+import java.util.ArrayList; 
+import java.io.File; 
+import java.io.BufferedReader; 
+import java.io.PrintWriter; 
+import java.io.InputStream; 
+import java.io.OutputStream; 
+import java.io.IOException; 
+
+public class staticclass extends PApplet {
+  public void setup() {
+class Button {
+  
+  int x, y, radius;
+  
+  public Button (int x, int y, int radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+  
+  public boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius;
+  }
+  
+  public void draw() {
+    ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+  }
+  
+}
+    noLoop();
+  }
+
+  static public void main(String[] passedArgs) {
+    String[] appletArgs = new String[] { "staticclass" };
+    if (passedArgs != null) {
+      PApplet.main(concat(appletArgs, passedArgs));
+    } else {
+      PApplet.main(appletArgs);
+    }
+  }
+}

--- a/java/test/resources/staticclass.pde
+++ b/java/test/resources/staticclass.pde
@@ -1,0 +1,19 @@
+class Button {
+  
+  int x, y, radius;
+  
+  public Button (int x, int y, int radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+  
+  boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius;
+  }
+  
+  void draw() {
+    ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+  }
+  
+}


### PR DESCRIPTION
Closes #579:

It looks like Processing 3 was a bit more eager to try to put the user in static mode. I’m not 100% sure but I think this might have accidentally caused some undesired wrapping previously. Regardless, I replicate the 3x behavior while still supporting Java mode by:

 - Try matching static mode before Java mode.
 - If there is ambiguity, check for main in the root object provided by the user.
 - Check if the user is trying to import processing core manually and avoid double import of automatic includes.

This PR adds tests both from #579 and also a new test where the mode is ambiguous but root object includes a main method.