### PR TITLE
Check for sanitary folder names

### DIFF
--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1618,7 +1618,7 @@ public class Base {
         Messages.showWarning("You're tricky, but not tricky enough",
           pdeFile.getName() + " is not a valid name for sketch code.\n" +
           "Better to stick to ASCII, no spaces, and make sure\n" +
-          "it doesn't start with a number.", null);
+          "it doesn't start with a number or contains hyphens.", null);
         return null;
       }
 

--- a/app/src/processing/app/Base.java
+++ b/app/src/processing/app/Base.java
@@ -1553,6 +1553,14 @@ public class Base {
 
     File parentFolder = pdeFile.getParentFile();
 
+    if (!Sketch.isSanitaryName(parentFolder.getName())) {
+      Messages.showWarning("You're tricky, but not tricky enough",
+          parentFolder.getName() + " is not a valid name for a sketch folder.\n" +
+              "Better to stick to ASCII, no spaces, and make sure\n" +
+              "it doesn't start with a number or contains hyphens.", null);
+      return null;
+    }
+
     try {
       // read the sketch.properties file or get an empty Settings object
       Settings props = Sketch.loadProperties(parentFolder);


### PR DESCRIPTION
This PR fixes #610.

In older versions of Processing, the sketch folder had to have the same name as the sketch itself.
This isn't the case anymore, so folder names have to be checked themselves.