### PR TITLE
Fix static mode visibility injection when annotation present

### DIFF
--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -591,7 +591,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
       if (annoationPoint == null) {
         insertBefore(possibleModifiers.getStart(), "public ");
       } else {
-        insertAfter(annoationPoint.getStop(), "public ");
+        insertAfter(annoationPoint.getStop(), " public ");
       }
     }
 

--- a/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
+++ b/java/src/processing/mode/java/preproc/PdeParseTreeListener.java
@@ -566,7 +566,7 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
     int numChildren = possibleModifiers.getChildCount();
 
-    ParserRuleContext annoationPoint = null;
+    ParserRuleContext annotationPoint = null;
 
     for (int i = 0; i < numChildren; i++) {
       boolean childIsVisibility;
@@ -582,16 +582,16 @@ public class PdeParseTreeListener extends ProcessingBaseListener {
 
       boolean isModifier = child instanceof ProcessingParser.ModifierContext;
       if (isModifier && isAnnotation((ProcessingParser.ModifierContext) child)) {
-        annoationPoint = (ParserRuleContext) child;
+        annotationPoint = (ParserRuleContext) child;
       }
     }
 
     // Insert at start of method or after annoation
     if (!hasVisibilityModifier) {
-      if (annoationPoint == null) {
+      if (annotationPoint == null) {
         insertBefore(possibleModifiers.getStart(), "public ");
       } else {
-        insertAfter(annoationPoint.getStop(), " public ");
+        insertAfter(annotationPoint.getStop(), " public ");
       }
     }
 

--- a/java/test/processing/mode/java/ParserTests.java
+++ b/java/test/processing/mode/java/ParserTests.java
@@ -319,6 +319,11 @@ public class ParserTests {
   }
 
   @Test
+  public void staticannotations() {
+    expectGood("staticannotations", true);
+  }
+
+  @Test
   public void generics() {
     expectGood("generics", true);
   }

--- a/java/test/resources/staticannotations.expected
+++ b/java/test/resources/staticannotations.expected
@@ -1,0 +1,65 @@
+import processing.core.*; 
+import processing.data.*; 
+import processing.event.*; 
+import processing.opengl.*; 
+
+import java.util.HashMap; 
+import java.util.ArrayList; 
+import java.io.File; 
+import java.io.BufferedReader; 
+import java.io.PrintWriter; 
+import java.io.InputStream; 
+import java.io.OutputStream; 
+import java.io.IOException; 
+
+public class staticannotations extends PApplet {
+  
+  public void setup() {
+
+class Button {
+  
+  int x, y, radius;
+  
+  public Button (int x, int y, int radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+  
+  boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius;
+  }
+  
+  void draw() {
+    ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+  }
+
+  @Deprecated
+  void old() {
+    ellipse(this.x, this.y, this.radius, this.radius);
+  }
+  
+}
+
+
+class ButtonOther extends Button {
+
+  @Override
+  boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius / 2;
+  }
+
+}
+
+    noLoop();
+  }
+
+  static public void main(String[] passedArgs) {
+    String[] appletArgs = new String[] { "staticannotations" };
+    if (passedArgs != null) {
+      PApplet.main(concat(appletArgs, passedArgs));
+    } else {
+      PApplet.main(appletArgs);
+    }
+  }
+}

--- a/java/test/resources/staticannotations.expected
+++ b/java/test/resources/staticannotations.expected
@@ -26,16 +26,16 @@ class Button {
     this.radius = radius;
   }
   
-  boolean over() {
+  public boolean over() {
     return dist(mouseX, mouseY, this.x, this.y) < this.radius;
   }
   
-  void draw() {
+  public void draw() {
     ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
   }
 
   @Deprecated
-  void old() {
+  public void old() {
     ellipse(this.x, this.y, this.radius, this.radius);
   }
   
@@ -45,7 +45,7 @@ class Button {
 class ButtonOther extends Button {
 
   @Override
-  boolean over() {
+  public boolean over() {
     return dist(mouseX, mouseY, this.x, this.y) < this.radius / 2;
   }
 

--- a/java/test/resources/staticannotations.pde
+++ b/java/test/resources/staticannotations.pde
@@ -1,0 +1,34 @@
+class Button {
+  
+  int x, y, radius;
+  
+  public Button (int x, int y, int radius) {
+    this.x = x;
+    this.y = y;
+    this.radius = radius;
+  }
+  
+  boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius;
+  }
+  
+  void draw() {
+    ellipse(this.x, this.y, this.radius * 2, this.radius * 2);
+  }
+
+  @Deprecated
+  void old() {
+    ellipse(this.x, this.y, this.radius, this.radius);
+  }
+  
+}
+
+
+class ButtonOther extends Button {
+
+  @Override
+  boolean over() {
+    return dist(mouseX, mouseY, this.x, this.y) < this.radius / 2;
+  }
+
+}


### PR DESCRIPTION
Closes #619 - There is a problem with adding public to members when wrapping in “static” mode processing sketches introduced by removing the leading space in #609. Requires preproc to look for leading annnotations before injecting visibility modifier. Apologies @benfry and @knupel.