### PR TITLE
Support chained decimals during SVG Parsing

### DIFF
--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -515,6 +515,7 @@ public class PShapeSVG extends PShape {
 
     StringBuilder pathBuffer = new StringBuilder();
     boolean lastSeparate = false;
+    boolean isOnDecimal = false;
 
     for (int i = 0; i < pathDataChars.length; i++) {
       char c = pathDataChars[i];
@@ -538,6 +539,13 @@ public class PShapeSVG extends PShape {
       }
       if (c == 'Z' || c == 'z') {
         separate = false;
+      }
+      if (c == '.' && !isOnDecimal) {
+        isOnDecimal = true;
+      }
+      else if (isOnDecimal && (c < '0' || c > '9')) {
+        pathBuffer.append("|");
+        isOnDecimal = c == '.';
       }
       if (c == '-' && !lastSeparate) {
         // allow for 'e' notation in numbers, e.g. 2.10e-9

--- a/core/test/processing/core/PShapeSVGTest.java
+++ b/core/test/processing/core/PShapeSVGTest.java
@@ -1,0 +1,32 @@
+package processing.core;
+
+import org.junit.Assert;
+import org.junit.Test;
+import processing.data.XML;
+import processing.core.PImage;
+
+import java.awt.*;
+
+
+public class PShapeSVGTest {
+
+  private static final String TEST_CONTENT = "<svg><g><path d=\"L 0,3.1.4.1\"/></g></svg>";
+
+  @Test
+  public void testDecimals() {
+    try {
+      XML xml = XML.parse(TEST_CONTENT);
+      PShapeSVG shape = new PShapeSVG(xml);
+      PShape[] children = shape.getChildren();
+      Assert.assertEquals(1, children.length);
+      PShape[] grandchildren = children[0].getChildren();
+      Assert.assertEquals(1, grandchildren.length);
+      Assert.assertEquals(0, grandchildren[0].getChildCount());
+      Assert.assertEquals(2, grandchildren[0].getVertexCount());
+    }
+    catch (Exception e) {
+      Assert.fail("Encountered exception " + e);
+    }
+  }
+
+}


### PR DESCRIPTION
@benfry took a stab at the fix discussed for #515 along with a new test that catches the issue.
Currently, when there are 2+ decimals in a row without any whitespace or other separators in-between, we treat the whole thing as a single token. Added some logic to add a separator at the end of each set of decimal digits to handle this case.