### PR TITLE
Fix error highlighting in IDE.

### DIFF
--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -21,16 +21,76 @@
 package processing.app;
 
 
+/**
+ * Structure describing a problem encountered in sketch compilation.
+ */
 public interface Problem {
+
+  /**
+   * Get if the problem is an error that prevented compilation.
+   * 
+   * @return True if an error such that the sketch did not compile and false
+   *    otherwise.
+   */
   public boolean isError();
+
+  /**
+   * Get if the problem is an warning that did not prevent compilation.
+   * 
+   * @return True if a warning and the sketch compiled and false otherwise.
+   */
   public boolean isWarning();
 
+  /**
+   * Get which tab (sketch file) the problem was encountered.
+   * 
+   * @return The index of the tab in which the problem was encountered.
+   */
   public int getTabIndex();
-  public int getLineNumber();  // 0-indexed
+
+  /**
+   * Get at which line the problem was encountered.
+   * 
+   * @return Zero-indexed line number within the tab at getTabIndex in which
+   *    this problem was encountered. Note that this is not the line in the
+   *    generated Java file.
+   */
+  public int getLineNumber();
+
+  /**
+   * Get a human-reabable description of the problem encountered.
+   * 
+   * @return String describing the error or warning encountered.
+   */
   public String getMessage();
 
+  /**
+   * Determine against what reference point for the this Problem's specific
+   * location is reported.
+   * 
+   * @return True if getStartOffset and getStopOffset are number of characters
+   *    relative to the start of the line reported by getLineNumber. False if
+   *    getStartOffset and getStopOffset are number of characters from start of
+   *    the tab.
+   */
   public boolean usesLineOffset();
+
+  /**
+   * Get the exact character on which this problem starts in code.
+   * 
+   * @return Number of characters past the reference point in usesLineOffset
+   *     at which this problem starts (where the code to which the problem
+   *     is attributed starts).
+   */
   public int getStartOffset();
+
+  /**
+   * Get the exact character on which this problem ends in code.
+   * 
+   * @return Number of characters past the reference point in usesLineOffset
+   *     at which this problem ends (where the code to which the problem
+   *     is attributed ends).
+   */
   public int getStopOffset();
 }
 

--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -17,6 +17,7 @@
   along with this program; if not, write to the Free Software Foundation, Inc.
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
+
 package processing.app;
 
 

--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -20,11 +20,28 @@
 
 package processing.app;
 
+import java.util.Optional;
+
 
 /**
  * Structure describing a problem encountered in sketch compilation.
  */
 public interface Problem {
+
+  /**
+   * Strategy converting line number in tab to character offset from tab start.
+   */
+  public interface LineToTabOffsetGetter {
+
+    /**
+     * Convert a line number to the number of characters past tab start.
+     * 
+     * @param line The line number to convert.
+     * @return The number of characters past tab start where that line starts.
+     */
+    public int get(int line);
+
+  }
 
   /**
    * Get if the problem is an error that prevented compilation.
@@ -65,32 +82,55 @@ public interface Problem {
   public String getMessage();
 
   /**
-   * Determine against what reference point for the this Problem's specific
-   * location is reported.
+   * Get the exact character on which this problem starts in code tab relative.
    * 
-   * @return True if getStartOffset and getStopOffset are number of characters
-   *    relative to the start of the line reported by getLineNumber. False if
-   *    getStartOffset and getStopOffset are number of characters from start of
-   *    the tab.
+   * @return Number of characters past the start of the tab if known where the
+   *    code associated with the Problem starts. Returns empty if not provided.
    */
-  public boolean usesLineOffset();
+  public Optional<Integer> getTabStartOffset();
 
   /**
-   * Get the exact character on which this problem starts in code.
+   * Get the exact character on which this problem ends in code tab relative.
    * 
-   * @return Number of characters past the reference point in usesLineOffset
-   *     at which this problem starts (where the code to which the problem
-   *     is attributed starts).
+   * @return Number of characters past the start of the tab if known where the
+   *    code associated with the Problem ends. Returns empty if not provided.
    */
-  public int getStartOffset();
+  public Optional<Integer> getTabStopOffset();
 
   /**
-   * Get the exact character on which this problem ends in code.
+   * Get the exact character on which this problem starts in code line relative.
    * 
-   * @return Number of characters past the reference point in usesLineOffset
-   *     at which this problem ends (where the code to which the problem
-   *     is attributed ends).
+   * @return Number of characters past the start of the line if known where the
+   *    code associated with the Problem starts. Returns empty if not provided.
    */
-  public int getStopOffset();
+  public Optional<Integer> getLineStartOffset();
+
+  /**
+   * Get the exact character on which this problem ends in code line relative.
+   * 
+   * @return Number of characters past the start of the line if known where the
+   *    code associated with the Problem ends. Returns empty if not provided.
+   */
+  public Optional<Integer> getLineStopOffset();
+
+  /**
+   * Get the exact character on which this problem ends in code tab relative.
+   * 
+   * @param strategy Strategy to convert line to tab start if needed.
+   * @return Number of characters past the start of the tab if known where the
+   *    code associated with the Problem ends, using the provided conversion
+   *    if needed. Returns line start if character position not given.
+   */
+  public int computeTabStartOffset(LineToTabOffsetGetter strategy);
+
+  /**
+   * Get the exact character on which this problem ends in code tab relative.
+   * 
+   * @param strategy Strategy to convert line to tab start if needed.
+   * @return Number of characters past the start of the tab if known where the
+   *    code associated with the Problem ends, using the provided conversion
+   *    if needed. Returns line start if character position not given.
+   */
+  public int computeTabStopOffset(LineToTabOffsetGetter strategy);
 }
 

--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -28,7 +28,7 @@ public interface Problem {
   public int getLineNumber();  // 0-indexed
   public String getMessage();
 
-  public boolean isLineOffset();
+  public boolean usesLineOffset();
   public int getStartOffset();
   public int getStopOffset();
 }

--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -17,7 +17,6 @@
   along with this program; if not, write to the Free Software Foundation, Inc.
   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 */
-
 package processing.app;
 
 
@@ -29,6 +28,7 @@ public interface Problem {
   public int getLineNumber();  // 0-indexed
   public String getMessage();
 
+  public boolean isLineOffset();
   public int getStartOffset();
   public int getStopOffset();
 }

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -152,6 +152,11 @@ public class PdeTextAreaPainter extends TextAreaPainter {
 
       int lineOffset = textArea.getLineStartOffset(line);
 
+      if (problem.isLineOffset()) {
+        startOffset += lineOffset;
+        stopOffset += lineOffset;
+      }
+
       int wiggleStart = Math.max(startOffset, lineOffset);
       int wiggleStop = Math.min(stopOffset, textArea.getLineStopOffset(line));
 

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -152,7 +152,7 @@ public class PdeTextAreaPainter extends TextAreaPainter {
 
       int lineOffset = textArea.getLineStartOffset(line);
 
-      if (problem.isLineOffset()) {
+      if (problem.usesLineOffset()) {
         startOffset += lineOffset;
         stopOffset += lineOffset;
       }

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2626,7 +2626,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
           int pEndOffset = p.getStopOffset();
 
           int pEndLine;
-          if (p.isLineOffset()) {
+          if (p.usesLineOffset()) {
             int lineGlobalOffset = textarea.getLineStartOffset(pStartLine);
             pEndLine = textarea.getLineOfOffset(pEndOffset + lineGlobalOffset);
           } else {

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2556,8 +2556,15 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
 
   public void highlight(Problem p) {
+    Problem.LineToTabOffsetGetter getter = (x) -> {
+      return textarea.getLineStartOffset(x);
+    };
+
     if (p != null) {
-      highlight(p.getTabIndex(), p.getStartOffset(), p.getStopOffset());
+      int tabIndex = p.getTabIndex();
+      int tabToStartOffset = p.computeTabStartOffset(getter);
+      int tabToStopOffset = p.computeTabStopOffset(getter);
+      highlight(tabIndex, tabToStartOffset, tabToStopOffset);
     }
   }
 
@@ -2623,15 +2630,10 @@ public abstract class Editor extends JFrame implements RunnerListener {
         .filter(p -> p.getTabIndex() == currentTab)
         .filter(p -> {
           int pStartLine = p.getLineNumber();
-          int pEndOffset = p.getStopOffset();
-
-          int pEndLine;
-          if (p.usesLineOffset()) {
-            int lineGlobalOffset = textarea.getLineStartOffset(pStartLine);
-            pEndLine = textarea.getLineOfOffset(pEndOffset + lineGlobalOffset);
-          } else {
-            pEndLine = textarea.getLineOfOffset(pEndOffset);
-          }
+          int pEndOffset = p.computeTabStopOffset(
+            (startLine) -> textarea.getLineStartOffset(pStartLine)
+          );
+          int pEndLine = textarea.getLineOfOffset(pEndOffset);
 
           return line >= pStartLine && line <= pEndLine;
         })

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2624,7 +2624,15 @@ public abstract class Editor extends JFrame implements RunnerListener {
         .filter(p -> {
           int pStartLine = p.getLineNumber();
           int pEndOffset = p.getStopOffset();
-          int pEndLine = textarea.getLineOfOffset(pEndOffset);
+
+          int pEndLine;
+          if (p.isLineOffset()) {
+            int lineGlobalOffset = textarea.getLineStartOffset(pStartLine);
+            pEndLine = textarea.getLineOfOffset(pEndOffset + lineGlobalOffset);
+          } else {
+            pEndLine = textarea.getLineOfOffset(pEndOffset);
+          }
+
           return line >= pStartLine && line <= pEndLine;
         })
         .collect(Collectors.toList());

--- a/java/src/processing/mode/java/ErrorChecker.java
+++ b/java/src/processing/mode/java/ErrorChecker.java
@@ -277,9 +277,16 @@ public class ErrorChecker {
             String q = matcher.group();
             int tabStart = in.startTabOffset + offset;
             int tabStop = tabStart + 1;
+            int line = ps.tabOffsetToTabLine(in.tabIndex, tabStart);
+            
             // Prevent duplicate problems
-            if (problems.stream().noneMatch(p -> p.getStartOffset() == tabStart)) {
-              int line = ps.tabOffsetToTabLine(in.tabIndex, tabStart);
+            boolean isDupe = problems.stream()
+              .filter(p -> p.getTabIndex() == in.tabIndex)
+              .filter(p -> p.getLineNumber() == line)
+              .findAny()
+              .isPresent();
+
+            if (isDupe) {
               String message;
               if (iproblem.getID() == IProblem.UnterminatedString) {
                 message = Language.interpolate("editor.status.unterm_string_curly", q);

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -82,7 +82,7 @@ public class JavaProblem implements Problem {
   }
 
 
-  public void setPDEOffsets(int startOffset, int stopOffset){
+  public void setPDEOffsets(int startOffset, int stopOffset) {
     this.startOffset = startOffset;
     this.stopOffset = stopOffset;
   }
@@ -139,6 +139,9 @@ public class JavaProblem implements Problem {
     importSuggestions = a;
   }
 
+  public boolean isLineOffset() {
+    return false;
+  }
 
   @Override
   public String toString() {

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -82,7 +82,7 @@ public class JavaProblem implements Problem {
   }
 
 
-  public void setPDEOffsets(int startOffset, int stopOffset) {
+  public void setPDEOffsets(int startOffset, int stopOffset){
     this.startOffset = startOffset;
     this.stopOffset = stopOffset;
   }

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -139,7 +139,7 @@ public class JavaProblem implements Problem {
     importSuggestions = a;
   }
 
-  public boolean isLineOffset() {
+  public boolean usesLineOffset() {
     return false;
   }
 

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -20,6 +20,8 @@ along with this program; if not, write to the Free Software Foundation, Inc.
 
 package processing.mode.java;
 
+import java.util.Optional;
+
 import org.eclipse.jdt.core.compiler.IProblem;
 
 import processing.app.Problem;
@@ -42,9 +44,9 @@ public class JavaProblem implements Problem {
   /** Line number (pde code) of the error */
   private final int lineNumber;
 
-  private int startOffset;
+  private Optional<Integer> startOffset;
 
-  private int stopOffset;
+  private Optional<Integer> stopOffset;
 
   /**
    * If the error is a 'cannot find type' contains the list of suggested imports
@@ -60,6 +62,8 @@ public class JavaProblem implements Problem {
     this.type = type;
     this.tabIndex = tabIndex;
     this.lineNumber = lineNumber;
+    this.startOffset = Optional.empty();
+    this.stopOffset = Optional.empty();
   }
 
 
@@ -83,22 +87,31 @@ public class JavaProblem implements Problem {
 
 
   public void setPDEOffsets(int startOffset, int stopOffset){
-    this.startOffset = startOffset;
-    this.stopOffset = stopOffset;
+    this.startOffset = Optional.of(startOffset);
+    this.stopOffset = Optional.of(stopOffset);
   }
 
 
   @Override
-  public int getStartOffset() {
+  public Optional<Integer> getTabStartOffset() {
     return startOffset;
   }
 
 
   @Override
-  public int getStopOffset() {
+  public Optional<Integer> getTabStopOffset() {
     return stopOffset;
   }
 
+  @Override
+  public Optional<Integer> getLineStartOffset() {
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Integer> getLineStopOffset() {
+    return Optional.empty();
+  }
 
   @Override
   public boolean isError() {
@@ -149,4 +162,37 @@ public class JavaProblem implements Problem {
         + startOffset + ",LN STOP OFF: " + stopOffset + ",PROB: "
         + message;
   }
+
+  @Override
+  public int computeTabStartOffset(LineToTabOffsetGetter strategy) {
+    Optional<Integer> nativeTabStartOffset = getTabStartOffset();
+    if (nativeTabStartOffset.isPresent()) {
+      return nativeTabStartOffset.get();
+    }
+
+    Optional<Integer> lineStartOffset = getLineStartOffset();
+    int lineOffset = strategy.get(getLineNumber());
+    if (lineStartOffset.isPresent()) {
+      return lineOffset + lineStartOffset.get();
+    } else {
+      return lineOffset;
+    }
+  }
+
+  @Override
+  public int computeTabStopOffset(LineToTabOffsetGetter strategy) {
+    Optional<Integer> nativeTabStopOffset = getTabStopOffset();
+    if (nativeTabStopOffset.isPresent()) {
+      return nativeTabStopOffset.get();
+    }
+
+    Optional<Integer> lineStopOffset = getLineStopOffset();
+    int lineOffset = strategy.get(getLineNumber());
+    if (lineStopOffset.isPresent()) {
+      return lineOffset + lineStopOffset.get();
+    } else {
+      return lineOffset;
+    }
+  }
+
 }

--- a/java/src/processing/mode/java/ProblemFactory.java
+++ b/java/src/processing/mode/java/ProblemFactory.java
@@ -53,7 +53,8 @@ public class ProblemFactory {
         localLine,
         message,
         lineStart,
-        lineStop
+        lineStop,
+        false
     );
   }
 
@@ -83,8 +84,9 @@ public class ProblemFactory {
         tab,
         localLine,
         message,
-        localLine,
-        localLine + col
+        0,
+        col,
+        true
     );
   }
 

--- a/java/src/processing/mode/java/SyntaxProblem.java
+++ b/java/src/processing/mode/java/SyntaxProblem.java
@@ -19,14 +19,14 @@ public class SyntaxProblem extends JavaProblem  {
    * @param newLineNumber The line number within the tab at which the offending code can be found.
    * @param newMessage Human readable message describing the issue.
    * @param newStartOffset The character index at which the issue starts. This is relative to start
-   *    of tab / file not relative to start of line if newIsLineOffset is true else it is line
+   *    of tab / file not relative to start of line if newUsesLineOffset is true else it is line
    *    offset.
    * @param newStopOffset The character index at which the issue ends. This is relative to start
-   *    of tab / file not relative to start of line if newIsLineOffset is true else it is line
+   *    of tab / file not relative to start of line if newUsesLineOffset is true else it is line
    *    offset.
    */
   public SyntaxProblem(int newTabIndex, int newLineNumber, String newMessage, int newStartOffset,
-                       int newStopOffset, boolean newIsLineOffset) {
+                       int newStopOffset, boolean newUsesLineOffset) {
 
     super(newMessage, JavaProblem.ERROR, newLineNumber, newLineNumber);
 
@@ -35,7 +35,7 @@ public class SyntaxProblem extends JavaProblem  {
     message = newMessage;
     startOffset = newStartOffset;
     stopOffset = newStopOffset;
-    lineFlag = newIsLineOffset;
+    lineFlag = newUsesLineOffset;
   }
 
   @Override
@@ -73,7 +73,7 @@ public class SyntaxProblem extends JavaProblem  {
     return stopOffset;
   }
 
-  public boolean isLineOffset() {
+  public boolean usesLineOffset() {
     return lineFlag;
   }
 

--- a/java/src/processing/mode/java/SyntaxProblem.java
+++ b/java/src/processing/mode/java/SyntaxProblem.java
@@ -1,4 +1,25 @@
+/*
+Part of the Processing project - http://processing.org
+Copyright (c) 2012-15 The Processing Foundation
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2
+as published by the Free Software Foundation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation, Inc.
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+*/
+
 package processing.mode.java;
+
+import java.util.Optional;
+
 
 /**
  * Problem identifying a syntax error found in preprocessing.
@@ -8,9 +29,10 @@ public class SyntaxProblem extends JavaProblem  {
   private final int tabIndex;
   private final int lineNumber;
   private final String message;
-  private final int startOffset;
-  private final int stopOffset;
-  private final boolean lineFlag;
+  private final Optional<Integer> tabStartOffset;
+  private final Optional<Integer> tabStopOffset;
+  private final Optional<Integer> lineStartOffset;
+  private final Optional<Integer> lineStopOffset;
 
   /**
    * Create a new syntax problem.
@@ -33,9 +55,18 @@ public class SyntaxProblem extends JavaProblem  {
     tabIndex = newTabIndex;
     lineNumber = newLineNumber;
     message = newMessage;
-    startOffset = newStartOffset;
-    stopOffset = newStopOffset;
-    lineFlag = newUsesLineOffset;
+
+    if (newUsesLineOffset) {
+      lineStartOffset = Optional.of(newStartOffset);
+      lineStopOffset = Optional.of(newStopOffset);
+      tabStartOffset = Optional.empty();
+      tabStopOffset = Optional.empty();
+    } else {
+      lineStartOffset = Optional.empty();
+      lineStopOffset = Optional.empty();
+      tabStartOffset = Optional.of(newStartOffset);
+      tabStopOffset = Optional.of(newStopOffset);
+    }
   }
 
   @Override
@@ -64,17 +95,23 @@ public class SyntaxProblem extends JavaProblem  {
   }
 
   @Override
-  public int getStartOffset() {
-    return startOffset;
+  public Optional<Integer> getTabStartOffset() {
+    return tabStartOffset;
   }
 
   @Override
-  public int getStopOffset() {
-    return stopOffset;
+  public Optional<Integer> getTabStopOffset() {
+    return tabStopOffset;
   }
 
-  public boolean usesLineOffset() {
-    return lineFlag;
+  @Override
+  public Optional<Integer> getLineStartOffset() {
+    return lineStartOffset;
+  }
+
+  @Override
+  public Optional<Integer> getLineStopOffset() {
+    return lineStopOffset;
   }
 
 }

--- a/java/src/processing/mode/java/SyntaxProblem.java
+++ b/java/src/processing/mode/java/SyntaxProblem.java
@@ -10,6 +10,7 @@ public class SyntaxProblem extends JavaProblem  {
   private final String message;
   private final int startOffset;
   private final int stopOffset;
+  private final boolean lineFlag;
 
   /**
    * Create a new syntax problem.
@@ -18,12 +19,14 @@ public class SyntaxProblem extends JavaProblem  {
    * @param newLineNumber The line number within the tab at which the offending code can be found.
    * @param newMessage Human readable message describing the issue.
    * @param newStartOffset The character index at which the issue starts. This is relative to start
-   *    of tab / file not relative to start of line.
+   *    of tab / file not relative to start of line if newIsLineOffset is true else it is line
+   *    offset.
    * @param newStopOffset The character index at which the issue ends. This is relative to start
-   *    *    of tab / file not relative to start of line.
+   *    of tab / file not relative to start of line if newIsLineOffset is true else it is line
+   *    offset.
    */
   public SyntaxProblem(int newTabIndex, int newLineNumber, String newMessage, int newStartOffset,
-                       int newStopOffset) {
+                       int newStopOffset, boolean newIsLineOffset) {
 
     super(newMessage, JavaProblem.ERROR, newLineNumber, newLineNumber);
 
@@ -32,6 +35,7 @@ public class SyntaxProblem extends JavaProblem  {
     message = newMessage;
     startOffset = newStartOffset;
     stopOffset = newStopOffset;
+    lineFlag = newIsLineOffset;
   }
 
   @Override
@@ -67,6 +71,10 @@ public class SyntaxProblem extends JavaProblem  {
   @Override
   public int getStopOffset() {
     return stopOffset;
+  }
+
+  public boolean isLineOffset() {
+    return lineFlag;
   }
 
 }

--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -233,13 +233,13 @@ class PdeAdapter {
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), prob.getStartOffset())
+                .toLineCol(code.getProgram(), prob.getTabStartOffset().get())
                 .col - 1
             ),
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), prob.getStopOffset())
+                .toLineCol(code.getProgram(), prob.getTabStopOffset().get())
                 .col - 1
             )
           ),

--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -228,18 +228,25 @@ class PdeAdapter {
       Map<URI, List<Diagnostic>> dias = problems.stream()
       .map(prob -> {
         SketchCode code = sketch.getCode(prob.getTabIndex());
+
+        Optional<Integer> startOffset = prob.getTabStartOffset();
+        Optional<Integer> endOffset = prob.getTabStopOffset();
+
+        assert startOffset.isPresent();
+        assert endOffset.isPresent();
+
         Diagnostic dia = new Diagnostic(
           new Range(
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), prob.getTabStartOffset().get())
+                .toLineCol(code.getProgram(), startOffset.get())
                 .col - 1
             ),
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), prob.getTabStopOffset().get())
+                .toLineCol(code.getProgram(), endOffset.get())
                 .col - 1
             )
           ),


### PR DESCRIPTION
Error highlighting is a bit broken (see #714).

**Root cause:** Depending on how the `Problem` is made, the error may be given relative to start of line or start of tab. Changed method names to indicate to users of `Problem`s which one they are working with.

I think this may have been [introduced in the language server support effort as `Problems` may be made without Editor available](https://github.com/processing/processing4/commit/ac062a502dec646dd2f332ea12c32efc01064b1c). The behavior in #714 appears to have started then but there was a delay before it showed up in production given how releases were done.

**Resolution:** I clarified the interface and gave client code ability to determine if they want / need a `Problem `to be placed relative to start of line or start of tab where each are more convenient in different contexts.