### PR TITLE
Tweaks fix for transparency

### DIFF
--- a/java/src/processing/mode/java/tweak/SketchParser.java
+++ b/java/src/processing/mode/java/tweak/SketchParser.java
@@ -270,7 +270,7 @@ public class SketchParser {
    * list of all hexadecimal numbers in the sketch
    */
   private void addAllWebColorNumbers() {
-    Pattern p = Pattern.compile("#[A-Fa-f0-9]{6}");
+    Pattern p = Pattern.compile("#([A-Fa-f0-9]{2})?[A-Fa-f0-9]{6}");
     for (int i=0; i<codeTabs.length; i++)
     {
       String c = codeTabs[i];


### PR DESCRIPTION
Closes #720

Fix an issue where tweaks mode wont run if there are semi-transparent colors in the tab because of a regex issue.