### PR TITLE
Fix the language server / PDE error highlighting another way

### DIFF
--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -29,21 +29,6 @@ import java.util.Optional;
 public interface Problem {
 
   /**
-   * Strategy converting line number in tab to character offset from tab start.
-   */
-  public interface LineToTabOffsetGetter {
-
-    /**
-     * Convert a line number to the number of characters past tab start.
-     * 
-     * @param line The line number to convert.
-     * @return The number of characters past tab start where that line starts.
-     */
-    public int get(int line);
-
-  }
-
-  /**
    * Get if the problem is an error that prevented compilation.
    * 
    * @return True if an error such that the sketch did not compile and false
@@ -82,28 +67,12 @@ public interface Problem {
   public String getMessage();
 
   /**
-   * Get the exact character on which this problem starts in code tab relative.
-   * 
-   * @return Number of characters past the start of the tab if known where the
-   *    code associated with the Problem starts. Returns empty if not provided.
-   */
-  public Optional<Integer> getTabStartOffset();
-
-  /**
-   * Get the exact character on which this problem ends in code tab relative.
-   * 
-   * @return Number of characters past the start of the tab if known where the
-   *    code associated with the Problem ends. Returns empty if not provided.
-   */
-  public Optional<Integer> getTabStopOffset();
-
-  /**
    * Get the exact character on which this problem starts in code line relative.
    * 
    * @return Number of characters past the start of the line if known where the
    *    code associated with the Problem starts. Returns empty if not provided.
    */
-  public Optional<Integer> getLineStartOffset();
+  public Optional<Integer> getStartOffset();
 
   /**
    * Get the exact character on which this problem ends in code line relative.
@@ -111,26 +80,7 @@ public interface Problem {
    * @return Number of characters past the start of the line if known where the
    *    code associated with the Problem ends. Returns empty if not provided.
    */
-  public Optional<Integer> getLineStopOffset();
+  public Optional<Integer> getStopOffset();
 
-  /**
-   * Get the exact character on which this problem ends in code tab relative.
-   * 
-   * @param strategy Strategy to convert line to tab start if needed.
-   * @return Number of characters past the start of the tab if known where the
-   *    code associated with the Problem ends, using the provided conversion
-   *    if needed. Returns line start if character position not given.
-   */
-  public int computeTabStartOffset(LineToTabOffsetGetter strategy);
-
-  /**
-   * Get the exact character on which this problem ends in code tab relative.
-   * 
-   * @param strategy Strategy to convert line to tab start if needed.
-   * @return Number of characters past the start of the tab if known where the
-   *    code associated with the Problem ends, using the provided conversion
-   *    if needed. Returns line start if character position not given.
-   */
-  public int computeTabStopOffset(LineToTabOffsetGetter strategy);
 }
 

--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -70,17 +70,17 @@ public interface Problem {
    * Get the exact character on which this problem starts in code line relative.
    * 
    * @return Number of characters past the start of the line if known where the
-   *    code associated with the Problem starts. Returns empty if not provided.
+   *    code associated with the Problem starts.
    */
-  public Optional<Integer> getStartOffset();
+  public int getStartOffset();
 
   /**
    * Get the exact character on which this problem ends in code line relative.
    * 
    * @return Number of characters past the start of the line if known where the
-   *    code associated with the Problem ends. Returns empty if not provided.
+   *    code associated with the Problem ends.
    */
-  public Optional<Integer> getStopOffset();
+  public int getStopOffset();
 
 }
 

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -326,7 +326,7 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   public String getToolTipText(MouseEvent event) {
     fontMetrics = getFontMetrics();
     int line = event.getY() / fontMetrics.getHeight() + textArea.getFirstLine();
-    if (line >= 0 || line < textArea.getLineCount()) {
+    if (line >= 0 || line < textArea.getLineCount()) {getPreprocessIssues
       List<Problem> problems = getEditor().findProblems(line);
       for (Problem problem : problems) {
         int lineStart = textArea.getLineStartOffset(line);
@@ -337,6 +337,8 @@ public class PdeTextAreaPainter extends TextAreaPainter {
 
         int startOffset = Math.max(errorStart, lineStart) - lineStart;
         int stopOffset = Math.min(errorEnd, lineEnd) - lineStart;
+
+        System.out.println(lineStart + "\t" + lineEnd + "\t" + errorStart + "\t" + errorEnd + "\t" + startOffset + "\t" + stopOffset);
 
         int x = event.getX();
 

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -147,6 +147,7 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   protected void paintErrorLine(Graphics gfx, int line, int x) {
     List<Problem> problems = getEditor().findProblems(line);
     for (Problem problem : problems) {
+      System.out.println("here");
       int lineOffsetStart = textArea.getLineStartOffset(line);
       int lineOffsetStop = textArea.getLineStopOffset(line);
 
@@ -326,7 +327,7 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   public String getToolTipText(MouseEvent event) {
     fontMetrics = getFontMetrics();
     int line = event.getY() / fontMetrics.getHeight() + textArea.getFirstLine();
-    if (line >= 0 || line < textArea.getLineCount()) {getPreprocessIssues
+    if (line >= 0 || line < textArea.getLineCount()) {
       List<Problem> problems = getEditor().findProblems(line);
       for (Problem problem : problems) {
         int lineStart = textArea.getLineStartOffset(line);
@@ -337,8 +338,6 @@ public class PdeTextAreaPainter extends TextAreaPainter {
 
         int startOffset = Math.max(errorStart, lineStart) - lineStart;
         int stopOffset = Math.min(errorEnd, lineEnd) - lineStart;
-
-        System.out.println(lineStart + "\t" + lineEnd + "\t" + errorStart + "\t" + errorEnd + "\t" + startOffset + "\t" + stopOffset);
 
         int x = event.getX();
 

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -46,8 +46,6 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   protected Color gutterTextInactiveColor;
   protected Color gutterHighlightColor;
 
-  private final Problem.LineToTabOffsetGetter lineToTabOffsetGetter;
-
 
   public PdeTextAreaPainter(JEditTextArea textArea, TextAreaDefaults defaults) {
     super(textArea, defaults);
@@ -78,10 +76,6 @@ public class PdeTextAreaPainter extends TextAreaPainter {
         }
       }
     });
-
-    lineToTabOffsetGetter = (x) -> {
-      return textArea.getLineStartOffset(x);
-    };
   }
 
 
@@ -153,11 +147,11 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   protected void paintErrorLine(Graphics gfx, int line, int x) {
     List<Problem> problems = getEditor().findProblems(line);
     for (Problem problem : problems) {
-      int startOffset = problem.computeTabStartOffset(lineToTabOffsetGetter);
-      int stopOffset = problem.computeTabStopOffset(lineToTabOffsetGetter);
-
       int lineOffsetStart = textArea.getLineStartOffset(line);
       int lineOffsetStop = textArea.getLineStopOffset(line);
+
+      int startOffset = lineOffsetStart + problem.getStartOffset();
+      int stopOffset = lineOffsetStart + problem.getStopOffset();
 
       int wiggleStart = Math.max(startOffset, lineOffsetStart);
       int wiggleStop = Math.min(stopOffset, lineOffsetStop);
@@ -338,8 +332,8 @@ public class PdeTextAreaPainter extends TextAreaPainter {
         int lineStart = textArea.getLineStartOffset(line);
         int lineEnd = textArea.getLineStopOffset(line);
 
-        int errorStart = problem.computeTabStartOffset(lineToTabOffsetGetter);
-        int errorEnd = problem.computeTabStopOffset(lineToTabOffsetGetter) + 1;
+        int errorStart = lineStart + problem.getStartOffset();
+        int errorEnd = lineStart + problem.getStopOffset();
 
         int startOffset = Math.max(errorStart, lineStart) - lineStart;
         int stopOffset = Math.min(errorEnd, lineEnd) - lineStart;

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -147,15 +147,11 @@ public class PdeTextAreaPainter extends TextAreaPainter {
   protected void paintErrorLine(Graphics gfx, int line, int x) {
     List<Problem> problems = getEditor().findProblems(line);
     for (Problem problem : problems) {
-      System.out.println("here");
       int lineOffsetStart = textArea.getLineStartOffset(line);
       int lineOffsetStop = textArea.getLineStopOffset(line);
 
-      int startOffset = lineOffsetStart + problem.getStartOffset();
-      int stopOffset = lineOffsetStart + problem.getStopOffset();
-
-      int wiggleStart = Math.max(startOffset, lineOffsetStart);
-      int wiggleStop = Math.min(stopOffset, lineOffsetStop);
+      int wiggleStart = lineOffsetStart + problem.getStartOffset();
+      int wiggleStop = lineOffsetStart + problem.getStopOffset();
 
       int y = textArea.lineToY(line) + getLineDisplacement();
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2633,8 +2633,7 @@ public abstract class Editor extends JFrame implements RunnerListener {
           int lineOffset = textarea.getLineStartOffset(pStartLine);
           int pEndOffset = lineOffset + p.getStopOffset();
           int pEndLine = textarea.getLineOfOffset(pEndOffset);
-
-          System.out.println(line + "\t" + pStartLine + "\t" + pEndLine);
+          
           return line >= pStartLine && line <= pEndLine;
         })
         .collect(Collectors.toList());

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2630,10 +2630,11 @@ public abstract class Editor extends JFrame implements RunnerListener {
         .filter(p -> p.getTabIndex() == currentTab)
         .filter(p -> {
           int pStartLine = p.getLineNumber();
-          int lineOffset = textarea.getLineOfOffset(pStartLine);
+          int lineOffset = textarea.getLineStartOffset(pStartLine);
           int pEndOffset = lineOffset + p.getStopOffset();
           int pEndLine = textarea.getLineOfOffset(pEndOffset);
 
+          System.out.println(line + "\t" + pStartLine + "\t" + pEndLine);
           return line >= pStartLine && line <= pEndLine;
         })
         .collect(Collectors.toList());

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -2556,16 +2556,16 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
 
   public void highlight(Problem p) {
-    Problem.LineToTabOffsetGetter getter = (x) -> {
-      return textarea.getLineStartOffset(x);
-    };
-
-    if (p != null) {
-      int tabIndex = p.getTabIndex();
-      int tabToStartOffset = p.computeTabStartOffset(getter);
-      int tabToStopOffset = p.computeTabStopOffset(getter);
-      highlight(tabIndex, tabToStartOffset, tabToStopOffset);
+    if (p == null) {
+      return;
     }
+
+    int tabIndex = p.getTabIndex();
+    int lineNumber = p.getLineNumber();
+    int lineStart = textarea.getLineStartOffset(lineNumber);
+    int tabToStartOffset = lineStart + p.getStartOffset();
+    int tabToStopOffset = lineStart + p.getStopOffset();
+    highlight(tabIndex, tabToStartOffset, tabToStopOffset);
   }
 
 
@@ -2630,9 +2630,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
         .filter(p -> p.getTabIndex() == currentTab)
         .filter(p -> {
           int pStartLine = p.getLineNumber();
-          int pEndOffset = p.computeTabStopOffset(
-            (startLine) -> textarea.getLineStartOffset(pStartLine)
-          );
+          int lineOffset = textarea.getLineOfOffset(pStartLine);
+          int pEndOffset = lineOffset + p.getStopOffset();
           int pEndLine = textarea.getLineOfOffset(pEndOffset);
 
           return line >= pStartLine && line <= pEndLine;

--- a/java/src/processing/mode/java/ErrorChecker.java
+++ b/java/src/processing/mode/java/ErrorChecker.java
@@ -199,7 +199,7 @@ public class ErrorChecker {
       String badCode = ps.getPdeCode(in);
       int line = ps.tabOffsetToTabLine(in.tabIndex, in.startTabOffset);
       JavaProblem p = JavaProblem.fromIProblem(iproblem, in.tabIndex, line, badCode);
-      p.setPDEOffsets(in.startTabOffset, in.stopTabOffset);
+      p.setPDEOffsets(0, 1);  // TODO
       return p;
     }
     return null;
@@ -252,7 +252,6 @@ public class ErrorChecker {
 
       String message = Language.interpolate("editor.status.bad_curly_quote", q);
       JavaProblem problem = new JavaProblem(message, JavaProblem.ERROR, tabIndex, tabLine);
-      problem.setPDEOffsets(tabOffset, tabOffset+1);
 
       problems.add(problem);
     }
@@ -294,7 +293,6 @@ public class ErrorChecker {
                 message = Language.interpolate("editor.status.bad_curly_quote", q);
               }
               JavaProblem p = new JavaProblem(message, JavaProblem.ERROR, in.tabIndex, line);
-              p.setPDEOffsets(tabStart, tabStop);
               problems2.add(p);
             }
           }

--- a/java/src/processing/mode/java/ErrorChecker.java
+++ b/java/src/processing/mode/java/ErrorChecker.java
@@ -199,7 +199,7 @@ public class ErrorChecker {
       String badCode = ps.getPdeCode(in);
       int line = ps.tabOffsetToTabLine(in.tabIndex, in.startTabOffset);
       JavaProblem p = JavaProblem.fromIProblem(iproblem, in.tabIndex, line, badCode);
-      p.setPDEOffsets(0, 1);  // TODO
+      p.setPDEOffsets(0, iproblem.getSourceEnd() - iproblem.getSourceStart());
       return p;
     }
     return null;

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -118,7 +118,7 @@ public class JavaEditor extends Editor {
     // setting breakpoints will flag sketch as modified, so override this here
     getSketch().setModified(false);
 
-    preprocService = new PreprocService(this.jmode, this.sketch); 
+    preprocService = new PreprocService(this.jmode, this.sketch, this); 
 
 //    long t5 = System.currentTimeMillis();
 

--- a/java/src/processing/mode/java/JavaEditor.java
+++ b/java/src/processing/mode/java/JavaEditor.java
@@ -118,7 +118,7 @@ public class JavaEditor extends Editor {
     // setting breakpoints will flag sketch as modified, so override this here
     getSketch().setModified(false);
 
-    preprocService = new PreprocService(this.jmode, this.sketch, this); 
+    preprocService = new PreprocService(this.jmode, this.sketch); 
 
 //    long t5 = System.currentTimeMillis();
 

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -60,6 +60,10 @@ public class JavaProblem implements Problem {
     this.type = type;
     this.tabIndex = tabIndex;
     this.lineNumber = lineNumber;
+
+    // Default to 0, 1 unless a longer section is specified
+    this.startOffset = 0;
+    this.stopOffset = 1;
   }
 
 

--- a/java/src/processing/mode/java/JavaProblem.java
+++ b/java/src/processing/mode/java/JavaProblem.java
@@ -20,8 +20,6 @@ along with this program; if not, write to the Free Software Foundation, Inc.
 
 package processing.mode.java;
 
-import java.util.Optional;
-
 import org.eclipse.jdt.core.compiler.IProblem;
 
 import processing.app.Problem;
@@ -44,9 +42,9 @@ public class JavaProblem implements Problem {
   /** Line number (pde code) of the error */
   private final int lineNumber;
 
-  private Optional<Integer> startOffset;
+  private int startOffset;
 
-  private Optional<Integer> stopOffset;
+  private int stopOffset;
 
   /**
    * If the error is a 'cannot find type' contains the list of suggested imports
@@ -62,8 +60,6 @@ public class JavaProblem implements Problem {
     this.type = type;
     this.tabIndex = tabIndex;
     this.lineNumber = lineNumber;
-    this.startOffset = Optional.empty();
-    this.stopOffset = Optional.empty();
   }
 
 
@@ -87,30 +83,20 @@ public class JavaProblem implements Problem {
 
 
   public void setPDEOffsets(int startOffset, int stopOffset){
-    this.startOffset = Optional.of(startOffset);
-    this.stopOffset = Optional.of(stopOffset);
+    this.startOffset = startOffset;
+    this.stopOffset = stopOffset;
   }
 
 
   @Override
-  public Optional<Integer> getTabStartOffset() {
+  public int getStartOffset() {
     return startOffset;
   }
 
 
   @Override
-  public Optional<Integer> getTabStopOffset() {
+  public int getStopOffset() {
     return stopOffset;
-  }
-
-  @Override
-  public Optional<Integer> getLineStartOffset() {
-    return Optional.empty();
-  }
-
-  @Override
-  public Optional<Integer> getLineStopOffset() {
-    return Optional.empty();
   }
 
   @Override
@@ -161,38 +147,6 @@ public class JavaProblem implements Problem {
     return "TAB " + tabIndex + ",LN " + lineNumber + "LN START OFF: "
         + startOffset + ",LN STOP OFF: " + stopOffset + ",PROB: "
         + message;
-  }
-
-  @Override
-  public int computeTabStartOffset(LineToTabOffsetGetter strategy) {
-    Optional<Integer> nativeTabStartOffset = getTabStartOffset();
-    if (nativeTabStartOffset.isPresent()) {
-      return nativeTabStartOffset.get();
-    }
-
-    Optional<Integer> lineStartOffset = getLineStartOffset();
-    int lineOffset = strategy.get(getLineNumber());
-    if (lineStartOffset.isPresent()) {
-      return lineOffset + lineStartOffset.get();
-    } else {
-      return lineOffset;
-    }
-  }
-
-  @Override
-  public int computeTabStopOffset(LineToTabOffsetGetter strategy) {
-    Optional<Integer> nativeTabStopOffset = getTabStopOffset();
-    if (nativeTabStopOffset.isPresent()) {
-      return nativeTabStopOffset.get();
-    }
-
-    Optional<Integer> lineStopOffset = getLineStopOffset();
-    int lineOffset = strategy.get(getLineNumber());
-    if (lineStopOffset.isPresent()) {
-      return lineOffset + lineStopOffset.get();
-    } else {
-      return lineOffset;
-    }
   }
 
 }

--- a/java/src/processing/mode/java/PreprocService.java
+++ b/java/src/processing/mode/java/PreprocService.java
@@ -93,17 +93,34 @@ public class PreprocService {
   private volatile boolean running;
   private CompletableFuture<PreprocSketch> preprocessingTask = new CompletableFuture<>();
 
+  private JavaEditor editor;
+
   private CompletableFuture<?> lastCallback =
     new CompletableFuture<>() {{
       complete(null); // initialization block
     }};
 
   /**
-   * Create a new preprocessing service to support an editor.
+   * Create a new preprocessing service to support the language server.
    */
   public PreprocService(JavaMode javaMode, Sketch sketch) {
     this.javaMode = javaMode;
     this.sketch = sketch;
+
+    // Register listeners for first run
+    whenDone(this::fireListeners);
+
+    preprocessingThread = new Thread(this::mainLoop, "ECS");
+    preprocessingThread.start();
+  }
+
+  /**
+   * Create a new preprocessing service to support an editor.
+   */
+  public PreprocService(JavaMode javaMode, Sketch sketch, JavaEditor editor) {
+    this.javaMode = javaMode;
+    this.sketch = sketch;
+    this.editor = editor;
 
     // Register listeners for first run
     whenDone(this::fireListeners);
@@ -411,10 +428,18 @@ public class PreprocService {
       throw new RuntimeException("Unexpected sketch exception in preprocessing: " + e);
     }
 
+    final int endNumLines = numLines;
+
     if (preprocessorResult.getPreprocessIssues().size() > 0) {
-      preprocessorResult.getPreprocessIssues().stream()
+      if (editor == null) {
+        preprocessorResult.getPreprocessIssues().stream()
           .map((x) -> ProblemFactory.build(x, tabLineStarts))
           .forEach(result.otherProblems::add);
+      } else {
+        preprocessorResult.getPreprocessIssues().stream()
+          .map((x) -> ProblemFactory.build(x, tabLineStarts, endNumLines, editor))
+          .forEach(result.otherProblems::add);
+      }
 
       result.hasSyntaxErrors = true;
     }

--- a/java/src/processing/mode/java/PreprocService.java
+++ b/java/src/processing/mode/java/PreprocService.java
@@ -93,8 +93,6 @@ public class PreprocService {
   private volatile boolean running;
   private CompletableFuture<PreprocSketch> preprocessingTask = new CompletableFuture<>();
 
-  private JavaEditor editor;
-
   private CompletableFuture<?> lastCallback =
     new CompletableFuture<>() {{
       complete(null); // initialization block
@@ -106,21 +104,6 @@ public class PreprocService {
   public PreprocService(JavaMode javaMode, Sketch sketch) {
     this.javaMode = javaMode;
     this.sketch = sketch;
-
-    // Register listeners for first run
-    whenDone(this::fireListeners);
-
-    preprocessingThread = new Thread(this::mainLoop, "ECS");
-    preprocessingThread.start();
-  }
-
-  /**
-   * Create a new preprocessing service to support an editor.
-   */
-  public PreprocService(JavaMode javaMode, Sketch sketch, JavaEditor editor) {
-    this.javaMode = javaMode;
-    this.sketch = sketch;
-    this.editor = editor;
 
     // Register listeners for first run
     whenDone(this::fireListeners);
@@ -431,15 +414,9 @@ public class PreprocService {
     final int endNumLines = numLines;
 
     if (preprocessorResult.getPreprocessIssues().size() > 0) {
-      if (editor == null) {
-        preprocessorResult.getPreprocessIssues().stream()
-          .map((x) -> ProblemFactory.build(x, tabLineStarts))
-          .forEach(result.otherProblems::add);
-      } else {
-        preprocessorResult.getPreprocessIssues().stream()
-          .map((x) -> ProblemFactory.build(x, tabLineStarts, endNumLines, editor))
-          .forEach(result.otherProblems::add);
-      }
+      preprocessorResult.getPreprocessIssues().stream()
+        .map((x) -> ProblemFactory.build(x, tabLineStarts))
+        .forEach(result.otherProblems::add);
 
       result.hasSyntaxErrors = true;
     }

--- a/java/src/processing/mode/java/ProblemFactory.java
+++ b/java/src/processing/mode/java/ProblemFactory.java
@@ -52,9 +52,8 @@ public class ProblemFactory {
         tab,
         localLine,
         message,
-        lineStart,
-        lineStop,
-        false
+        0,
+        lineStop - lineStart
     );
   }
 
@@ -85,8 +84,7 @@ public class ProblemFactory {
         localLine,
         message,
         0,
-        col,
-        true
+        col
     );
   }
 

--- a/java/src/processing/mode/java/ProblemFactory.java
+++ b/java/src/processing/mode/java/ProblemFactory.java
@@ -19,49 +19,6 @@ public class ProblemFactory {
    *
    * @param pdePreprocessIssue The preprocess issue found.
    * @param tabStarts The list of line numbers on which each tab starts.
-   * @param editor The editor in which errors will appear.
-   * @return Newly created problem.
-   */
-  public static Problem build(PdePreprocessIssue pdePreprocessIssue, List<Integer> tabStarts,
-      int numLines, Editor editor) {
-
-    int line = pdePreprocessIssue.getLine();
-
-    // Sometimes errors are reported one line past end of sketch. Fix that.
-    if (line >= numLines) {
-      line = numLines - 1;
-    }
-
-    // Get local area
-    TabLine tabLine = getTab(tabStarts, line);
-
-    int tab = tabLine.getTab();
-    int localLine = tabLine.getLineInTab(); // Problems emitted in 0 index
-
-    // Generate syntax problem
-    String message = pdePreprocessIssue.getMsg();
-
-    int lineStart = editor.getLineStartOffset(localLine);
-    int lineStop = editor.getLineStopOffset(localLine) - 1;
-
-    if (lineStart == lineStop) {
-      lineStop++;
-    }
-
-    return new SyntaxProblem(
-        tab,
-        localLine,
-        message,
-        0,
-        lineStop - lineStart
-    );
-  }
-
-  /**
-   * Create a new {Problem}.
-   *
-   * @param pdePreprocessIssue The preprocess issue found.
-   * @param tabStarts The list of line numbers on which each tab starts.
    * @return Newly created problem.
    */
   public static Problem build(PdePreprocessIssue pdePreprocessIssue, List<Integer> tabStarts) {

--- a/java/src/processing/mode/java/SyntaxProblem.java
+++ b/java/src/processing/mode/java/SyntaxProblem.java
@@ -29,10 +29,8 @@ public class SyntaxProblem extends JavaProblem  {
   private final int tabIndex;
   private final int lineNumber;
   private final String message;
-  private final Optional<Integer> tabStartOffset;
-  private final Optional<Integer> tabStopOffset;
-  private final Optional<Integer> lineStartOffset;
-  private final Optional<Integer> lineStopOffset;
+  private final int lineStartOffset;
+  private final int lineStopOffset;
 
   /**
    * Create a new syntax problem.
@@ -40,33 +38,19 @@ public class SyntaxProblem extends JavaProblem  {
    * @param newTabIndex The tab number containing the source with the syntax issue.
    * @param newLineNumber The line number within the tab at which the offending code can be found.
    * @param newMessage Human readable message describing the issue.
-   * @param newStartOffset The character index at which the issue starts. This is relative to start
-   *    of tab / file not relative to start of line if newUsesLineOffset is true else it is line
-   *    offset.
-   * @param newStopOffset The character index at which the issue ends. This is relative to start
-   *    of tab / file not relative to start of line if newUsesLineOffset is true else it is line
-   *    offset.
+   * @param newStartOffset The character index at which the issue starts relative to line.
+   * @param newStopOffset The character index at which the issue end relative to line.
    */
   public SyntaxProblem(int newTabIndex, int newLineNumber, String newMessage, int newStartOffset,
-                       int newStopOffset, boolean newUsesLineOffset) {
+                       int newStopOffset) {
 
     super(newMessage, JavaProblem.ERROR, newLineNumber, newLineNumber);
 
     tabIndex = newTabIndex;
     lineNumber = newLineNumber;
     message = newMessage;
-
-    if (newUsesLineOffset) {
-      lineStartOffset = Optional.of(newStartOffset);
-      lineStopOffset = Optional.of(newStopOffset);
-      tabStartOffset = Optional.empty();
-      tabStopOffset = Optional.empty();
-    } else {
-      lineStartOffset = Optional.empty();
-      lineStopOffset = Optional.empty();
-      tabStartOffset = Optional.of(newStartOffset);
-      tabStopOffset = Optional.of(newStopOffset);
-    }
+    lineStartOffset = newStartOffset;
+    lineStopOffset = newStopOffset;
   }
 
   @Override
@@ -94,23 +78,11 @@ public class SyntaxProblem extends JavaProblem  {
     return message;
   }
 
-  @Override
-  public Optional<Integer> getTabStartOffset() {
-    return tabStartOffset;
-  }
-
-  @Override
-  public Optional<Integer> getTabStopOffset() {
-    return tabStopOffset;
-  }
-
-  @Override
-  public Optional<Integer> getLineStartOffset() {
+  public int getStartOffset() {
     return lineStartOffset;
   }
 
-  @Override
-  public Optional<Integer> getLineStopOffset() {
+  public int getStopOffset() {
     return lineStopOffset;
   }
 

--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -229,24 +229,21 @@ class PdeAdapter {
       .map(prob -> {
         SketchCode code = sketch.getCode(prob.getTabIndex());
 
-        Optional<Integer> startOffset = prob.getTabStartOffset();
-        Optional<Integer> endOffset = prob.getTabStopOffset();
-
-        assert startOffset.isPresent();
-        assert endOffset.isPresent();
+        int startOffset = prob.getStartOffset();
+        int endOffset = prob.getStopOffset();
 
         Diagnostic dia = new Diagnostic(
           new Range(
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), startOffset.get())
+                .toLineCol(code.getProgram(), startOffset)
                 .col - 1
             ),
             new Position(
               prob.getLineNumber(),
               PdeAdapter
-                .toLineCol(code.getProgram(), endOffset.get())
+                .toLineCol(code.getProgram(), endOffset)
                 .col - 1
             )
           ),


### PR DESCRIPTION
CC @benfry 

Retry #715. See below for original description.

> Depending on how the Problem is made, the error may be given relative to start of line or start of tab. I think this may have been [introduced in the language server support effort as Problems may be made without Editor available](https://github.com/processing/processing4/commit/ac062a502dec646dd2f332ea12c32efc01064b1c). The behavior in https://github.com/processing/processing4/issues/714 appears to have started then but there was a delay before it showed up in production given how releases were done.

Needs to address #751 in which the `Problem` interface cannot change in any way.

> Looks like a new method added to Problem is breaking the API for Modes. Any changes that are made need to allow contributed Modes (p5jsMode, Python, etc) to still run without a recompile so we need a better solution here. 

CC @benfry - Working on this will keep you posted.