### PR TITLE
Fix copyBufferFromSource throwing an exception

### DIFF
--- a/core/src/processing/opengl/Texture.java
+++ b/core/src/processing/opengl/Texture.java
@@ -823,11 +823,10 @@ public class Texture implements PConstants {
     } else {
       // The buffer cache reached the maximum size, so we just dispose
       // the new buffer by adding it to the list of used buffers.
-      try {
-        usedBuffers.add(new BufferData(natRef, byteBuf.asIntBuffer(), w, h));
-      } catch (Exception e) {
-        e.printStackTrace();
+      if (usedBuffers == null) {
+        usedBuffers = new LinkedList<BufferData>();
       }
+      usedBuffers.add(new BufferData(natRef, byteBuf.asIntBuffer(), w, h));
     }
   }
 


### PR DESCRIPTION
If usedBuffers was null and the buffer cache reached its maximum size, copyBufferFromSource would throw a null reference error. This adds a null check to that case to instantiate the usedBuffers list as is done elsewhere in this file.