### PR TITLE
Full line edt

### DIFF
--- a/app/src/processing/app/Problem.java
+++ b/app/src/processing/app/Problem.java
@@ -78,7 +78,7 @@ public interface Problem {
    * Get the exact character on which this problem ends in code line relative.
    * 
    * @return Number of characters past the start of the line if known where the
-   *    code associated with the Problem ends.
+   *    code associated with the Problem ends. If -1, should use the whole line.
    */
   public int getStopOffset();
 

--- a/app/src/processing/app/syntax/PdeTextAreaPainter.java
+++ b/app/src/processing/app/syntax/PdeTextAreaPainter.java
@@ -151,7 +151,8 @@ public class PdeTextAreaPainter extends TextAreaPainter {
       int lineOffsetStop = textArea.getLineStopOffset(line);
 
       int wiggleStart = lineOffsetStart + problem.getStartOffset();
-      int wiggleStop = lineOffsetStart + problem.getStopOffset();
+      int stopOffset = Editor.getProblemEditorLineStop(problem, lineOffsetStart, lineOffsetStop);
+      int wiggleStop = lineOffsetStart + stopOffset;
 
       int y = textArea.lineToY(line) + getLineDisplacement();
 
@@ -330,7 +331,8 @@ public class PdeTextAreaPainter extends TextAreaPainter {
         int lineEnd = textArea.getLineStopOffset(line);
 
         int errorStart = lineStart + problem.getStartOffset();
-        int errorEnd = lineStart + problem.getStopOffset();
+        int stopOffsetLine = Editor.getProblemEditorLineStop(problem, lineStart, lineEnd);
+        int errorEnd = lineStart + stopOffsetLine;
 
         int startOffset = Math.max(errorStart, lineStart) - lineStart;
         int stopOffset = Math.min(errorEnd, lineEnd) - lineStart;

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1030,11 +1030,9 @@ public abstract class Editor extends JFrame implements RunnerListener {
 
   static public int getProblemEditorLineStop(Problem problem, int lineStart, int lineStop) {
     int stopOffset = problem.getStopOffset();
-    System.out.println("> " + lineStart + " " + lineStop + " " + stopOffset);
     if (stopOffset == -1) {
       stopOffset = lineStop - lineStart;
     }
-    System.out.println("< " + lineStart + " " + lineStop + " " + stopOffset);
     return stopOffset;
   }
 

--- a/app/src/processing/app/ui/Editor.java
+++ b/app/src/processing/app/ui/Editor.java
@@ -1028,6 +1028,16 @@ public abstract class Editor extends JFrame implements RunnerListener {
     }
   }
 
+  static public int getProblemEditorLineStop(Problem problem, int lineStart, int lineStop) {
+    int stopOffset = problem.getStopOffset();
+    System.out.println("> " + lineStart + " " + lineStop + " " + stopOffset);
+    if (stopOffset == -1) {
+      stopOffset = lineStop - lineStart;
+    }
+    System.out.println("< " + lineStart + " " + lineStop + " " + stopOffset);
+    return stopOffset;
+  }
+
 
   // . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . . .
 
@@ -2563,8 +2573,11 @@ public abstract class Editor extends JFrame implements RunnerListener {
     int tabIndex = p.getTabIndex();
     int lineNumber = p.getLineNumber();
     int lineStart = textarea.getLineStartOffset(lineNumber);
+    int lineEnd = textarea.getLineStopOffset(lineNumber);
     int tabToStartOffset = lineStart + p.getStartOffset();
-    int tabToStopOffset = lineStart + p.getStopOffset();
+
+    int lineStopOffset = getProblemEditorLineStop(p, lineStart, lineEnd);
+    int tabToStopOffset = lineStart + lineStopOffset;
     highlight(tabIndex, tabToStartOffset, tabToStopOffset);
   }
 
@@ -2631,7 +2644,8 @@ public abstract class Editor extends JFrame implements RunnerListener {
         .filter(p -> {
           int pStartLine = p.getLineNumber();
           int lineOffset = textarea.getLineStartOffset(pStartLine);
-          int pEndOffset = lineOffset + p.getStopOffset();
+          int stopOffset = p.getStopOffset();
+          int pEndOffset = lineOffset + (stopOffset == -1 ? 0 : stopOffset);
           int pEndLine = textarea.getLineOfOffset(pEndOffset);
           
           return line >= pStartLine && line <= pEndLine;

--- a/java/src/processing/mode/java/ErrorChecker.java
+++ b/java/src/processing/mode/java/ErrorChecker.java
@@ -199,7 +199,7 @@ public class ErrorChecker {
       String badCode = ps.getPdeCode(in);
       int line = ps.tabOffsetToTabLine(in.tabIndex, in.startTabOffset);
       JavaProblem p = JavaProblem.fromIProblem(iproblem, in.tabIndex, line, badCode);
-      p.setPDEOffsets(0, iproblem.getSourceEnd() - iproblem.getSourceStart());
+      p.setPDEOffsets(0, -1);
       return p;
     }
     return null;

--- a/java/src/processing/mode/java/lsp/PdeAdapter.java
+++ b/java/src/processing/mode/java/lsp/PdeAdapter.java
@@ -112,8 +112,7 @@ class PdeAdapter {
 
   static Offset toLineEndCol(String s, int offset) {
     Offset before = toLineCol(s, offset);
-    int remaining = s.substring(offset).indexOf('\n');
-    return new Offset(before.line, before.col + remaining);
+    return new Offset(before.line, Integer.MAX_VALUE);
   }
 
   


### PR DESCRIPTION
We got pretty close on #752. However, the EDT often will place errors in unexpected places and with a width of 1 character (gives us a point where there was a problem but not the correct number of characters involved). This does not impact ANTLR issues.

I believe that, previous to the efforts to improve error highlighting, earlier versions of Processing 4 were highlighting the whole line but stuff related to #752 and #715 tried to make this more precise. This PR restores that earlier behavior and formalizes the interface. See attached.

Note that this does not impact upsteram errors in the build pipeline, only things that get through to the EDT. It also does not change behavior for errors reported at compile or runtime using javac directly.

![before](https://github.com/processing/processing4/assets/110391/c4b6862a-12a7-4cc4-8c14-8435d3ef38c2)
![after](https://github.com/processing/processing4/assets/110391/e644ad7f-2fd1-4d5b-b2d5-8b94870bfc50)
![after_vscode](https://github.com/processing/processing4/assets/110391/9b616f17-b2e6-4f7b-8c3b-f3d70a3a23fc)