### PR TITLE
fix #643 - PShape.beginContour() bug 

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1772,12 +1772,32 @@ public class PShape implements PConstants {
   protected void drawGeometry(PGraphics g) {
     // get cache object using g.
     g.beginShape(kind);
+
+    boolean insideContour = false;
+    int codeIndex = 0;
+
     if (style) {
       for (int i = 0; i < vertexCount; i++) {
+        if (vertexCodes[codeIndex++] == BREAK) {
+          if (insideContour) {
+            g.endContour();
+          }
+          g.beginContour();
+          insideContour = true;
+        }
+
         g.vertex(vertices[i]);
       }
     } else {
       for (int i = 0; i < vertexCount; i++) {
+        if (vertexCodes[codeIndex++] == BREAK) {
+          if (insideContour) {
+            g.endContour();
+          }
+          g.beginContour();
+          insideContour = true;
+        }
+
         float[] vert = vertices[i];
         if (vert.length < 3 || vert[Z] == 0) {
           g.vertex(vert[X], vert[Y]);
@@ -1785,6 +1805,10 @@ public class PShape implements PConstants {
           g.vertex(vert[X], vert[Y], vert[Z]);
         }
       }
+    }
+
+    if (insideContour) {
+      g.endContour();
     }
     g.endShape(close ? CLOSE : OPEN);
   }


### PR DESCRIPTION
Fix for bug #643.

I tested this with the default JAVA2D and FX2D renderers in the PDE using the [PShape.beginContour()](https://processing.org/reference/PShape_beginContour_.html) example code as well as some code in the #643 thread. Happy to do more testing as needed.