### PR TITLE
Fix broken 'Related' links in the Network and Serial library web reference

### DIFF
--- a/java/libraries/net/src/processing/net/Client.java
+++ b/java/libraries/net/src/processing/net/Client.java
@@ -41,7 +41,7 @@ import java.nio.charset.StandardCharsets;
  * @webBrief The client class is used to create client Objects which connect to a server to exchange data
  * @instanceName client any variable of type Client
  * @usage Application
- * @see_external LIB_net/clientEvent
+ * @see_external clientEvent
  */
 @SuppressWarnings("unused")
 public class Client implements Runnable {

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -41,7 +41,7 @@ import jssc.*;
  * @webBrief Class for sending and receiving data using the serial communication protocol
  * @instanceName serial any variable of type Serial
  * @usage Application
- * @see_external LIB_serial/serialEvent
+ * @see_external serialEvent
  */
 public class Serial implements SerialPortEventListener {
   PApplet parent;

--- a/java/libraries/serial/src/processing/serial/Serial.java
+++ b/java/libraries/serial/src/processing/serial/Serial.java
@@ -39,7 +39,6 @@ import jssc.*;
  *
  * @webref serial
  * @webBrief Class for sending and receiving data using the serial communication protocol
- * @instanceName serial any variable of type Serial
  * @usage Application
  * @see_external serialEvent
  */


### PR DESCRIPTION
Location of currently broken links (bottom of the page):
- https://processing.org/reference/libraries/net/Client.html
- https://processing.org/reference/libraries/serial/Serial.html

Known issue: the link to `serialEvent_.html` is still broken because the doclet actually creates the documentation at `Serial_serialEvent_.html` based on an internal library function that calls the user-defined `serialEvent()` function that the documentation is actually for. Either this file needs to be moved after generation (by the doclet script), or alternatively the documentation could be moved from the Javadoc to a static JSON file (this is also how it is done [for the Network library callback](https://github.com/processing/processing-website/blob/main/content/references/translations/en/net/clientEvent_.json)).

Also lets processing/processing-doclet/pull/6 choose an appropriate @instanceName (which closes processing/processing-website/issues/397)