### PR TITLE
Does the java version should be equal to the ant support version?

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -38,7 +38,7 @@
 
 
   <!-- Require Java ${train} everywhere. -->
-  <fail message="Unsupported Java version: ${java.version}. To build, make sure that Java ${jdk.train} is installed, and that JAVA_HOME points at the JDK that you want to use. For instance, on macOS, set it with:${line.separator}export JAVA_HOME=&quot;`/usr/libexec/java_home -v ${jdk.train}`&quot;">
+  <fail message="Unsupported Java version: ${java.version}. To build, make sure that Java ${jdk.train} is installed, the java version of ant you installed is equal to it, and that JAVA_HOME points at the JDK that you want to use. For instance, on macOS, set it with:${line.separator}export JAVA_HOME=&quot;`/usr/libexec/java_home -v ${jdk.train}`&quot;">
     <condition>
       <not>
         <or>


### PR DESCRIPTION
I fail to ant run.

reading build/build.xml, I find the condition that it should be equal to between the java version and the ant java version.
Shall we put it into the fail message?


$ export ANT_HOME="/Applications/apache-ant-1.10.1";
$ ant run
Buildfile: /Users/su2xu1/labs/processing4/build/build.xml

BUILD FAILED
/Users/su2xu1/labs/processing4/build/build.xml:41: Unsupported Java version: 17.0.8.1. To build, make sure that Java 17 is installed, and that JAVA_HOME points at the JDK that you want to use. For instance, on macOS, set it with:
export JAVA_HOME="`/usr/libexec/java_home -v 17`"

Total time: 0 seconds


$ export ANT_HOME="/Applications/apache-ant-1.10.14";
$ ant run
Buildfile: /Users/su2xu1/labs/processing4/build/build.xml

run:

revision-check:

,,,and BUILD is succeeded...
