### PR TITLE
Fix hash of keyEvent being added to pressedKeys.

### DIFF
--- a/core/src/processing/core/PApplet.java
+++ b/core/src/processing/core/PApplet.java
@@ -2627,16 +2627,15 @@ public class PApplet implements PConstants {
     keyEvent = event;
     key = event.getKey();
     keyCode = event.getKeyCode();
-
+    Long hash = ((long) keyCode << Character.SIZE);
     switch (event.getAction()) {
       case KeyEvent.PRESS -> {
-        Long hash = ((long) keyCode << Character.SIZE) | key;
         if (!pressedKeys.contains(hash)) pressedKeys.add(hash);
         keyPressed = true;
         keyPressed(keyEvent);
       }
       case KeyEvent.RELEASE -> {
-        pressedKeys.remove(((long) keyCode << Character.SIZE) | key);
+        pressedKeys.remove(hash);
         keyPressed = !pressedKeys.isEmpty();
         keyReleased(keyEvent);
       }


### PR DESCRIPTION
When we press a letter, lets say `d` is key is char value `d` and hash calculated using keyCodea and key is added to pressed keys. But when without release `d`, if we press `SHIFT` key, hash of shift key also being added to pressedKeys. Now, when we release `d`, it is actually now `D` hence key value change and when we try to remove new hash, it doesnot exist in pressedKeys and the old hash of `d` still stays in pressedKeys which was the cause of keyPressed returning true.

fixes #779 