### PR TITLE
fix #791

### DIFF
--- a/core/src/processing/core/PShape.java
+++ b/core/src/processing/core/PShape.java
@@ -1783,6 +1783,7 @@ public class PShape implements PConstants {
             g.endContour();
           }
           g.beginContour();
+          codeIndex++;
           insideContour = true;
         }
 
@@ -1795,6 +1796,7 @@ public class PShape implements PConstants {
             g.endContour();
           }
           g.beginContour();
+          codeIndex++;
           insideContour = true;
         }
 


### PR DESCRIPTION
Fix for #791.

Regrettably, when I tested the fix for #643 I didn't test shapes with multiple contours. This fix will increment the `codeIndex` variable so that the vertex codes from the `vertexCodes` array stay in line with the vertices in the `vertices` array.

```java
PShape s;

void setup() {
  size(400, 200);
  fill(255, 0, 0);
  noLoop();
}

void draw() {
  translate(50, 50);
  s = createShape();
  s.beginShape();
  s.fill(255, 0, 0);
  s.vertex(  0, 0);
  s.vertex(100, 0);
  s.vertex(100, 100);
  s.vertex(  0, 100);

  for (int x = 5; x <= 85; x += 20) {
    for (int y = 5; y <= 85; y += 20) {
      s.beginContour();
      s.vertex(x, y);
      s.vertex(x, y + 10);
      s.vertex(x + 10, y + 10);
      s.vertex(x + 10, y);
      s.endContour();
    }
  }

  s.endShape(CLOSE);
  shape(s, 0, 0);

  translate(200, 0);

  beginShape();
  fill(255, 0, 0);
  vertex( 0, 0);
  vertex(100, 0);
  vertex(100, 100);
  vertex(0, 100);

  for (int x = 5; x <= 85; x += 20) {
    for (int y = 5; y <= 85; y += 20) {
      beginContour();
      vertex(x, y);
      vertex(x, y + 10);
      vertex(x + 10, y + 10);
      vertex(x + 10, y);
      endContour();
    }
  }
 
  endShape(CLOSE);
}
```

![image](https://github.com/benfry/processing4/assets/4044283/18cb0090-147a-4f5d-b35c-19644b046b23)

I should have thought to test with multiple contours when I made the previous PR #776 .

Here's a much more complex example using real-life data from OpenStreetMap:

![image](https://github.com/benfry/processing4/assets/4044283/bf8fa30c-2721-4c16-b36a-c957a1031788)

There's a ton of contours in this shape it is drawn correctly.
