### PR TITLE
Move hotspot for the `TEXT` cursor type to the center of the icon

### DIFF
--- a/core/src/processing/opengl/PSurfaceJOGL.java
+++ b/core/src/processing/opengl/PSurfaceJOGL.java
@@ -1237,7 +1237,7 @@ public class PSurfaceJOGL implements PSurface {
             y = 8;
           } else if (kind == PConstants.TEXT) {
             x = 16;
-            y = 22;
+            y = 16;
           }
           cursor = new CursorInfo(img, x, y);
           cursors.put(kind, cursor);


### PR DESCRIPTION
In pretty much any program that has a text cursor when hovering over text, the hotspot position is located in the center of the icon, whereas Processing's text cursor hotspot is located at the bottom of the icon. This makes the cursor feel uncomfortable to use.

This pull request simply moves the hotspot to the center of the icon, following the convention set by most other software.

https://github.com/benfry/processing4/assets/48618519/db31eda5-28fb-4459-acf3-b0fa7897492e

