### PR TITLE
fixed issue#750 ArrayIndexOutOfBoundsException

### DIFF
--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -543,7 +543,7 @@ public class PShapeSVG extends PShape {
       if (c == '.' && !isOnDecimal) {
         isOnDecimal = true;
       }
-      else if (isOnDecimal && (c < '0' || c > '9')) {
+      else if (isOnDecimal && (c < '0' || c > '9') && c!='e' && c!='-') {
         pathBuffer.append("|");
         isOnDecimal = c == '.';
       }


### PR DESCRIPTION
Issue link : https://github.com/benfry/processing4/issues/750#issue-1806359306

Problem : It wasn't able to parse exponents leading to ArrayIndexOutOfBoundsException

Solution : handled that edge case. it will now be able to parse values such as 6.2e-4

Behavior after modification:
![image](https://github.com/benfry/processing4/assets/97651080/44aa6b93-5516-431a-88d1-fefe383c7f63)

