### PR TITLE
 fixed Issue#723 

### DIFF
--- a/core/src/processing/core/PImage.java
+++ b/core/src/processing/core/PImage.java
@@ -1315,7 +1315,13 @@ public class PImage implements PConstants, Cloneable {
           ri++;
           read += pixelWidth;
         }
-        pixels[x+yi] = (ca/sum)<<24 | (cr/sum)<<16 | (cg/sum)<<8 | (cb/sum);
+        
+        try {
+        pixels[x + yi] = (ca / sum) << 24 | (cr / sum) << 16 | (cg / sum) << 8 | (cb / sum);
+        } catch (ArithmeticException e) {
+          
+        }
+
       }
       yi += pixelWidth;
       ymi += pixelWidth;

--- a/core/src/processing/core/PShapeSVG.java
+++ b/core/src/processing/core/PShapeSVG.java
@@ -543,7 +543,7 @@ public class PShapeSVG extends PShape {
       if (c == '.' && !isOnDecimal) {
         isOnDecimal = true;
       }
-      else if (isOnDecimal && (c < '0' || c > '9')) {
+      else if (isOnDecimal && (c < '0' || c > '9') && c!='e' && c!='-') {
         pathBuffer.append("|");
         isOnDecimal = c == '.';
       }


### PR DESCRIPTION
Fixed : https://github.com/benfry/processing4/issues/723

Initial error :
When filter(BLUR, param) is called with param above a certain amount relative to the image size, an ArithmeticException is thrown for division by zero.

Current behaviour :
![image](https://github.com/benfry/processing4/assets/97651080/6ef168d8-e86f-41b9-b4fa-1da1f290f205)
![image](https://github.com/benfry/processing4/assets/97651080/db5d37ec-c35b-408b-b335-f52a4426006d)

Please let me know if any changes are required.